### PR TITLE
Only show HAProxy Traffic when HAProxy is enabled

### DIFF
--- a/Opserver/Views/Home/About.cshtml
+++ b/Opserver/Views/Home/About.cshtml
@@ -76,7 +76,7 @@
         <li>Redis: @EnabledSpan(s.Redis.Enabled)</li>
         <li>Elastic: @EnabledSpan(s.Elastic.Enabled)</li>
         <li>HAProxy: @EnabledSpan(s.HAProxy.Enabled)</li>
-        <li>HAProxy Traffic: @EnabledSpan(s.HAProxy.Traffic.Enabled)</li>
+        @if (s.HAProxy.Enabled) { <li>HAProxy Traffic: @EnabledSpan(s.HAProxy.Traffic.Enabled)</li> }
         <li>TeamCity: @EnabledSpan(s.TeamCity.Enabled)</li>
     </ul>
 </section>


### PR DESCRIPTION
Without this the /about page throws an exception when HAProxy is
disabled.
