### PR TITLE
Add SSL TeamCity config option

### DIFF
--- a/Opserver.Core/Data/BuildStatus.cs
+++ b/Opserver.Core/Data/BuildStatus.cs
@@ -129,7 +129,7 @@ namespace StackExchange.Opserver.Data
 
         public static TeamCityClient GetClient()
         {
-            var client = new TeamCityClient(Current.Settings.TeamCity.Url, useSsl: true);
+            var client = new TeamCityClient(Current.Settings.TeamCity.Url, useSsl: Current.Settings.TeamCity.UseSsl);
             client.Connect(Current.Settings.TeamCity.User, Current.Settings.TeamCity.Password);
             return client;
         }

--- a/Opserver.Core/Settings/TeamCitySettings.cs
+++ b/Opserver.Core/Settings/TeamCitySettings.cs
@@ -28,6 +28,7 @@ namespace StackExchange.Opserver
         {
             // Defaults
             BuildFetchIntervalSeconds = 30;
+            UseSsl = true;
         }
 
         /// <summary>
@@ -44,6 +45,11 @@ namespace StackExchange.Opserver
         /// Password to use when hitting the TeamCity API
         /// </summary>
         public string Password { get; set; }
+
+        /// <summary>
+        /// Should the dashboard connect to the TeamCity API via SSL
+        /// </summary>
+        public bool UseSsl { get; set; }
 
         /// <summary>
         /// How many seconds to cache builds for before fetching for new ones, defaults to 30

--- a/Opserver/Config/TeamCitySettings.json.example
+++ b/Opserver/Config/TeamCitySettings.json.example
@@ -1,5 +1,6 @@
 ﻿{
     "url": "my.teamcity.server.url",
+    "useSsl": true,
     "user": "teamcityuser",
     "password": "teamcitypass",
     "buildFetchIntervalSeconds": 30,


### PR DESCRIPTION
Allows connecting to TeamCity where SSL is not configured. Default the
config option to true.
