### PR TITLE
SQL Fixes and tweaks (Mainly 2005)

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.CPUHistory.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.CPUHistory.cs
@@ -40,7 +40,8 @@ namespace StackExchange.Opserver.Data.SQL
             public int ExternalProcessUtilization { get { return 100 - SystemIdle - ProcessUtilization; } }
 
             private const string _fetchSQL = @"
-Declare @ms_ticks bigint = (Select ms_ticks From sys.dm_os_sys_info);
+Declare @ms_ticks bigint;
+Set @ms_ticks = (Select ms_ticks From sys.dm_os_sys_info);
 
 Select Top (@maxEvents) DateAdd(ms, -1 * (@ms_ticks - timestamp_ms), GetUTCDate()) as EventTime, 
 	   ProcessUtilization,

--- a/Opserver.Core/Data/SQL/SQLInstance.Cache.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Cache.cs
@@ -30,7 +30,7 @@ namespace StackExchange.Opserver.Data.SQL
                 if (_standaloneInstances != null) return _standaloneInstances;
                 return Current.Settings.SQL.Enabled
                            ? Current.Settings.SQL.Instances
-                                    .Select(i => new SQLInstance(i.Name, i.ConnectionString))
+                                    .Select(i => new SQLInstance(i.Name, i.ConnectionString, i.ObjectName))
                                     .Where(i => i.TryAddToGlobalPollers())
                                     .ToList()
                            : new List<SQLInstance>();

--- a/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -413,7 +413,8 @@ Create Table #vlfTemp (
     CreateLSN nvarchar(255)
 );
 
-Declare @sql nvarchar(max) = '';
+Declare @sql nvarchar(max);
+Set @sql = '';
 Select @sql = @sql + ' Insert #vlfTemp Exec ' + QuoteName(name) + '.sys.sp_executesql N''DBCC LOGINFO WITH NO_INFOMSGS'';
   Insert #VLFCounts Select ' + Cast(database_id as nvarchar(10)) + ',''' + name + ''', Count(*) From #vlfTemp;
   Truncate Table #vlfTemp;'

--- a/Opserver.Core/Data/SQL/SQLInstance.Errors.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Errors.cs
@@ -31,10 +31,11 @@ namespace StackExchange.Opserver.Data.SQL
             public string Text { get; internal set; }
 
             internal const string FetchSQL = @"
-Declare @Time_Start varchar(30) = DATEADD(mi, -@minutesAgo, GETUTCDATE());
+Declare @Time_Start varchar(30);
+Set @Time_Start = DATEADD(mi, -@minutesAgo, GETUTCDATE());
 Declare @ErrorLog Table (LogDate datetime, ProcessInfo varchar(255), Text varchar(max));
 Insert Into @ErrorLog Exec master.dbo.xp_readerrorlog 0, 1, NULL, NULL, @Time_Start, NULL;
-Select * From @ErrorLog;";
+Select * From @ErrorLog Order By LogDate Desc;";
 
             public string GetFetchSQL(Version v)
             {

--- a/Opserver.Core/Data/SQL/SQLInstance.PerfCounters.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.PerfCounters.cs
@@ -27,8 +27,9 @@ namespace StackExchange.Opserver.Data.SQL
         public PerfCounterRecord GetPerfCounter(string category, string name, string instance)
         {
             var counters = PerfCounters.SafeData();
+            var objectName = this.ObjectName + ":" + category;
             return counters != null
-                       ? counters.FirstOrDefault(c => c.ObjectName == category && c.CounterName == name && c.InstanceName == instance)
+                       ? counters.FirstOrDefault(c => c.ObjectName == objectName && c.CounterName == name && c.InstanceName == instance)
                        : null;
         }
 

--- a/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
@@ -91,8 +91,8 @@ namespace StackExchange.Opserver.Data.SQL
                 }
             }
 
-            internal const string FetchSQL = @"
-Declare @sql nvarchar(4000) = '
+            internal const string FetchSQL = @"Declare @sql nvarchar(4000);
+Set @sql = '
 Select Cast(SERVERPROPERTY(''ProductVersion'') as nvarchar(128)) Version,
        @@VERSION FullVersion,
        Cast(SERVERPROPERTY(''ProductLevel'') as nvarchar(128)) Level,
@@ -115,18 +115,22 @@ Select Cast(SERVERPROPERTY(''ProductVersion'') as nvarchar(128)) Version,
        stack_size_in_bytes StackSizeBytes,
        max_workers_count MaxWorkersCount,
        scheduler_count SchedulerCount,
-       scheduler_total_count SchedulerTotalCount,
-       sqlserver_start_time SQLServerStartTime,
-       virtual_machine_type VirtualMachineType,';
+       scheduler_total_count SchedulerTotalCount,'
+       
+If (SELECT @@MICROSOFTVERSION / 0x01000000) >= 10
+	Set @sql = @sql + '
+       sqlserver_start_time SQLServerStartTime,';
 
 If (SELECT @@MICROSOFTVERSION / 0x01000000) >= 11
     Set @sql = @sql + '
+	   virtual_machine_type VirtualMachineType,	  
        Cast(physical_memory_kb as bigint) * 1024 PhysicalMemoryBytes,
        Cast(virtual_memory_kb as bigint) * 1024 VirtualMemoryBytes,
        Cast(committed_kb as bigint) * 1024 CommittedBytes,
        Cast(committed_target_kb as bigint) * 1024 CommittedTargetBytes';
 Else 
     Set @sql = @sql + '
+       null VirtualMachineType,
        physical_memory_in_bytes PhysicalMemoryBytes,
        virtual_memory_in_bytes VirtualMemoryBytes,
        Cast(bpool_committed as bigint) * 8 * 1024 CommittedBytes,

--- a/Opserver.Core/Data/SQL/SQLInstance.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.cs
@@ -13,6 +13,7 @@ namespace StackExchange.Opserver.Data.SQL
     public partial class SQLInstance : PollNode, ISearchableNode
     {
         public string Name { get; internal set; }
+        public string ObjectName { get; internal set; }
         public string CategoryName { get { return "SQL"; } }
         string ISearchableNode.DisplayName { get { return Name; } }
         protected string ConnectionString { get; set; }
@@ -36,10 +37,11 @@ namespace StackExchange.Opserver.Data.SQL
             }
         }
 
-        public SQLInstance(string name, string connectionString) : base(name)
+        public SQLInstance(string name, string connectionString, string objectName) : base(name)
         {
             Version = new Version(); // default to 0.0
             Name = name;
+            ObjectName = objectName.IsNullOrEmptyReturn(objectName, "SQLServer");
             ConnectionString = connectionString.IsNullOrEmptyReturn(Current.Settings.SQL.DefaultConnectionString.Replace("$ServerName$", name));
         }
 

--- a/Opserver.Core/Data/SQL/SQLNode.cs
+++ b/Opserver.Core/Data/SQL/SQLNode.cs
@@ -8,7 +8,7 @@ namespace StackExchange.Opserver.Data.SQL
     {
         public SQLCluster Cluster { get; internal set; }
 
-        public SQLNode(SQLCluster sqlCluster, SQLSettings.Instance node) : base(node.Name, node.ConnectionString)
+        public SQLNode(SQLCluster sqlCluster, SQLSettings.Instance node) : base(node.Name, node.ConnectionString, node.ObjectName)
         {
             Cluster = sqlCluster;
         }

--- a/Opserver.Core/Settings/SQLSettings.cs
+++ b/Opserver.Core/Settings/SQLSettings.cs
@@ -124,11 +124,16 @@ namespace StackExchange.Opserver
             /// </summary>
             public string ConnectionString { get; set; }
 
+            /// <summary>
+            /// Object Name for this instance
+            /// </summary>
+            public string ObjectName { get; set; }
+
             public bool Equals(Instance other)
             {
                 if (ReferenceEquals(null, other)) return false;
                 if (ReferenceEquals(this, other)) return true;
-                return string.Equals(Name, other.Name) && string.Equals(ConnectionString, other.ConnectionString);
+                return string.Equals(Name, other.Name) && string.Equals(ConnectionString, other.ConnectionString) && string.Equals(ObjectName, other.ObjectName);
             }
 
             public override bool Equals(object obj)

--- a/Opserver/Views/SQL/Databases.cshtml
+++ b/Opserver/Views/SQL/Databases.cshtml
@@ -1,4 +1,5 @@
-﻿@using StackExchange.Opserver.Data.SQL
+﻿@using System.Data
+@using StackExchange.Opserver.Data.SQL
 @using StackExchange.Opserver.Views.SQL
 @model DashboardModel
 @{
@@ -6,8 +7,9 @@
     var dbCache = s.Databases;
     var dbs = s.Databases.SafeData();
     var backupInfo = s.DatabaseBackups
-                      .SafeData(true)
-                      .ToDictionary(b => b.Id);
+                      .SafeData(true).Distinct()
+                      .GroupBy(db => db.Id)
+                      .ToDictionary(grp => grp.Key, grp => grp.First());
     var n = s as SQLNode;
     var replicationInfo = n != null ? n.AvailabilityGroups
                                        .SafeData(true)

--- a/Opserver/Views/SQL/Instance.cshtml
+++ b/Opserver/Views/SQL/Instance.cshtml
@@ -247,9 +247,9 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                             </tr>
                         </thead>
                         <tbody>
-                        @RenderPerSecCounter("SQLServer:Availability Replica", "Bytes Received from Replica/sec", "_Total")
-                        @RenderPerSecCounter("SQLServer:Availability Replica", "Bytes Sent to Replica/sec", "_Total")
-                        @RenderPerSecCounter("SQLServer:Availability Replica", "Bytes Sent to Transport/sec", "_Total")
+                        @RenderPerSecCounter("Availability Replica", "Bytes Received from Replica/sec", "_Total")
+                        @RenderPerSecCounter("Availability Replica", "Bytes Sent to Replica/sec", "_Total")
+                        @RenderPerSecCounter("Availability Replica", "Bytes Sent to Transport/sec", "_Total")
                         </tbody>
                     </table>
                 }
@@ -316,8 +316,8 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
     <div class="right-col">
         @if (counters.Any())
         {
-            var batchCounter = i.GetPerfCounter("SQLServer:SQL Statistics", "Batch Requests/sec", "");
-            var compCounter = i.GetPerfCounter("SQLServer:SQL Statistics", "SQL Compilations/sec", "");
+            var batchCounter = i.GetPerfCounter("SQL Statistics", "Batch Requests/sec", "");
+            var compCounter = i.GetPerfCounter("SQL Statistics", "SQL Compilations/sec", "");
             var compPercent = compCounter != null && batchCounter != null && batchCounter.CalculatedValue > 0 ? ((decimal)compCounter.CalculatedValue / batchCounter.CalculatedValue) : (decimal?)null;
             <div class="section-wrap refresh-group" data-name="instance-performance">
                 <div class="summary-section-header">Performance</div>
@@ -330,13 +330,13 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                         </tr>
                     </thead>
                     <tbody>
-                    @RenderPerSecCounter("SQLServer:SQL Statistics", "Batch Requests/sec", "", valueUrl: string.Format("/sql/top?node={0}&sort=ExecutionsPerMinute&LastRunSeconds=300", i.Name))
-                    @RenderPerSecCounter("SQLServer:SQL Statistics", "SQL Compilations/sec", "", toSuffix: v => compPercent.HasValue ? string.Format("({0}%)", compPercent.Value.ToString("##0.##")) : null)
-                    @RenderPerSecCounter("SQLServer:Databases", "Transactions/sec", "_Total")
+                    @RenderPerSecCounter("SQL Statistics", "Batch Requests/sec", "", valueUrl: string.Format("/sql/top?node={0}&sort=ExecutionsPerMinute&LastRunSeconds=300", i.Name))
+                    @RenderPerSecCounter("SQL Statistics", "SQL Compilations/sec", "", toSuffix: v => compPercent.HasValue ? string.Format("({0}%)", compPercent.Value.ToString("##0.##")) : null)
+                    @RenderPerSecCounter("Databases", "Transactions/sec", "_Total")
                         
-                    @RenderPerSecCounter("SQLServer:Access Methods", "Index Searches/sec", "")
-                    @RenderPerSecCounter("SQLServer:Locks", "Lock Requests/sec", "_Total")
-                    @RenderPerSecCounter("SQLServer:SQL Errors", "Errors/sec", "_Total", valueUrl: "#/sql/summary/errors") 
+                    @RenderPerSecCounter("Access Methods", "Index Searches/sec", "")
+                    @RenderPerSecCounter("Locks", "Lock Requests/sec", "_Total")
+                    @RenderPerSecCounter("SQL Errors", "Errors/sec", "_Total", valueUrl: "#/sql/summary/errors") 
                     </tbody>
                 </table>
             </div>
@@ -344,15 +344,15 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                 <table>
                     @Helpers.SectionHeader("Sizes")
                     <tbody>
-                        @RenderCounter("SQLServer:Memory Manager", "Total Server Memory (KB)", "", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Memory Manager", "Target Server Memory (KB)", "", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Memory Manager", "Database Cache Memory (KB)", "", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Memory Manager", "Free Memory (KB)", "", toSuffix: kbToSize)
+                        @RenderCounter("Memory Manager", "Total Server Memory (KB)", "", toSuffix: kbToSize)
+                        @RenderCounter("Memory Manager", "Target Server Memory (KB)", "", toSuffix: kbToSize)
+                        @RenderCounter("Memory Manager", "Database Cache Memory (KB)", "", toSuffix: kbToSize)
+                        @RenderCounter("Memory Manager", "Free Memory (KB)", "", toSuffix: kbToSize)
                         
-                        @RenderCounter("SQLServer:Databases", "Data File(s) Size (KB)", "_Total", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Databases", "Log File(s) Size (KB)", "_Total", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Databases", "Log File(s) Used Size (KB)", "_Total", toSuffix: kbToSize)
-                        @RenderCounter("SQLServer:Transactions", "Free Space in tempdb (KB)", "", toSuffix: kbToSize)
+                        @RenderCounter("Databases", "Data File(s) Size (KB)", "_Total", toSuffix: kbToSize)
+                        @RenderCounter("Databases", "Log File(s) Size (KB)", "_Total", toSuffix: kbToSize)
+                        @RenderCounter("Databases", "Log File(s) Used Size (KB)", "_Total", toSuffix: kbToSize)
+                        @RenderCounter("Transactions", "Free Space in tempdb (KB)", "", toSuffix: kbToSize)
                     </tbody>
                 </table>
             </div>
@@ -367,18 +367,18 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                         </tr>
                     </thead>
                     <tbody>
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Lock waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Log buffer waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Log write waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Network IO waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Non-Page latch waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Page IO latch waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Page latch waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Thread-safe memory objects waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Transaction ownership waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Wait for the worker", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Workspace synchronization waits", "Waits started per second")
-                    @RenderPerSecCounter("SQLServer:Wait Statistics", "Memory grant queue waits", "Cumulative wait time (ms) per second")
+                    @RenderPerSecCounter("Wait Statistics", "Lock waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Log buffer waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Log write waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Network IO waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Non-Page latch waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Page IO latch waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Page latch waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Thread-safe memory objects waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Transaction ownership waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Wait for the worker", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Workspace synchronization waits", "Waits started per second")
+                    @RenderPerSecCounter("Wait Statistics", "Memory grant queue waits", "Cumulative wait time (ms) per second")
                     </tbody>
                 </table>
             </div>*@
@@ -386,13 +386,13 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                 <table>
                     @Helpers.SectionHeader("Cache")
                     <tbody>
-                        @RenderCounter("SQLServer:Buffer Manager", "Page life expectancy", "", toSuffix: d => "seconds", tooltip: d => TimeSpan.FromSeconds((double)d).ToReadableString())
-                        @RenderCounter("SQLServer:Buffer Manager", "Page lookups/sec", "")
-                        @RenderCounter("SQLServer:Buffer Manager", "Database pages", "")
+                        @RenderCounter("Buffer Manager", "Page life expectancy", "", toSuffix: d => "seconds", tooltip: d => TimeSpan.FromSeconds((double)d).ToReadableString())
+                        @RenderCounter("Buffer Manager", "Page lookups/sec", "")
+                        @RenderCounter("Buffer Manager", "Database pages", "")
 
-                        @RenderCounter("SQLServer:Plan Cache", "Cache Object Counts", "_Total", "Objects in Cache")
-                        @RenderCounter("SQLServer:Plan Cache", "Cache Object Counts", "SQL Plans", "Plans in Cache")
-                        @RenderCounter("SQLServer:Plan Cache", "Cache Hit Ratio", "_Total")
+                        @RenderCounter("Plan Cache", "Cache Object Counts", "_Total", "Objects in Cache")
+                        @RenderCounter("Plan Cache", "Cache Object Counts", "SQL Plans", "Plans in Cache")
+                        @RenderCounter("Plan Cache", "Cache Hit Ratio", "_Total")
                     </tbody>
                 </table>
             </div>
@@ -401,14 +401,14 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                 <table>
                     @SectionHeader("Performance")
                     <tbody>
-                        @RenderCounter("SQLServer:General Statistics", "User Connections", "")
-                        @RenderCounter("SQLServer:General Statistics", "Connection Reset/sec", "")
+                        @RenderCounter("General Statistics", "User Connections", "")
+                        @RenderCounter("General Statistics", "Connection Reset/sec", "")
 
             
-                        @RenderCounter("SQLServer:Latches", "Average Latch Wait Time (ms)", "")
-                        @RenderCounter("SQLServer:Latches", "Latch Waits/sec", "")
+                        @RenderCounter("Latches", "Average Latch Wait Time (ms)", "")
+                        @RenderCounter("Latches", "Latch Waits/sec", "")
                     
-                        @RenderCounter("SQLServer:Workload Group Stats", "Requests completed/sec", "default")
+                        @RenderCounter("Workload Group Stats", "Requests completed/sec", "default")
                     </tbody>
                 </table>
             </div>*@


### PR DESCRIPTION
Tested with 2005, 2008, and 2008 R2. Made some tweaks to SQLInstance to support an instance with a non-default object name, fixes the queries that would error out due to syntax or unsupported columns.
