### PR TITLE
Elastic Search has indexes in it, but no stats available - give user nice message.

### DIFF
--- a/Opserver/Views/Elastic/Node.cshtml
+++ b/Opserver/Views/Elastic/Node.cshtml
@@ -262,35 +262,44 @@ Writes: @fsd.DiskWrites.ToComma() (@fsd.DiskWriteSizeInBytes.ToSize())">
                 <div class="section-wrap refresh-group" data-name="instance-indexes">
                     <div class="summary-section-header">Cluster Indexes
                         <a href="#/elastic/summary/indices" class="top-right-nav">View Detail</a></div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Index</th>
-                                <th>Searches</th>
-                                <th>Docs <span class="note">(Size) xCount</span></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            @foreach (var i in indexes.OrderByWorst().ThenBy(i => { int j; return int.TryParse(i.Name, out j) ? j : 0; }).ThenBy(i => i.Name))
-                            {
-                                var indexStat = indexStats[i.Name];
-                                <tr title="Status: @i.StringStatus
-Shards: @i.NumberOfShards.ToComma()
-Replicas: @i.NumberOfReplicas.ToComma()
 
-Active: @i.ActiveShards.ToComma()
-Active (Primary): @i.ActivePrimaryShards.ToComma()
-Initializing: @i.InitializingShards.ToComma()
-Relocating: @i.RelocatingShards.ToComma()
-Unassigned: @i.UnassignedShards.ToComma()">
-                                    <td>@i.IconSpan() 
-                                        <a href="#/elastic/index/@i.Name/shards">@c.GetIndexAliasedName(i.Name)</a></td>
-                                    <td>@indexStat.Total.Search.QueryTotal.ToComma()</td>
-                                    <td>@indexStat.Primaries.Documents.Count.ToComma() <span class="note">(@indexStat.Primaries.Store.SizeInBytes.ToSize()) <span title="@i.NumberOfReplicas.Pluralize("replica")">x@(i.NumberOfReplicas+1)</span></span></td>
+                    @if (indexStats.Count > 0) 
+                    {
+                        <table>
+                            <thead>
+                                <tr>
+                                    <th>Index</th>
+                                    <th>Searches</th>
+                                    <th>Docs <span class="note">(Size) xCount</span></th>
                                 </tr>
-                            }
-                        </tbody>
-                    </table>
+                            </thead>
+                            <tbody>
+                                    @foreach (var i in indexes.OrderByWorst().ThenBy(i => { int j; return int.TryParse(i.Name, out j) ? j : 0; }).ThenBy(i => i.Name))
+                                    {                                
+                                        var indexStat = indexStats[i.Name];
+                                        <tr title="Status: @i.StringStatus
+        Shards: @i.NumberOfShards.ToComma()
+        Replicas: @i.NumberOfReplicas.ToComma()
+
+        Active: @i.ActiveShards.ToComma()
+        Active (Primary): @i.ActivePrimaryShards.ToComma()
+        Initializing: @i.InitializingShards.ToComma()
+        Relocating: @i.RelocatingShards.ToComma()
+        Unassigned: @i.UnassignedShards.ToComma()">
+                                            <td>@i.IconSpan() 
+                                                <a href="#/elastic/index/@i.Name/shards">@c.GetIndexAliasedName(i.Name)</a></td>
+                                            <td>@indexStat.Total.Search.QueryTotal.ToComma()</td>
+                                            <td>@indexStat.Primaries.Documents.Count.ToComma() <span class="note">(@indexStat.Primaries.Store.SizeInBytes.ToSize()) <span title="@i.NumberOfReplicas.Pluralize("replica")">x@(i.NumberOfReplicas+1)</span></span></td>
+                                        </tr>
+                                    }
+                                }
+                            </tbody>
+                        </table>
+                    }
+                    else
+                    {
+                        <div class="note no-content">No stats available for existing indexes.</div>   
+                    }
                 </div>
             }
         </div>


### PR DESCRIPTION
By default when pointing at an Elastic Search node, if we have indexes, but no stats (because they are unhealthy), then don't error out, simply test for the case and then show the user a message.  

A little unsure what would be an effective message to get the user to resolve the problem.
