### PR TITLE
Elastic Search has indexes in it, but no stats available - give user nice message.

### DIFF
--- a/Opserver/Views/Elastic/Node.cshtml
+++ b/Opserver/Views/Elastic/Node.cshtml
@@ -292,7 +292,6 @@ Writes: @fsd.DiskWrites.ToComma() (@fsd.DiskWriteSizeInBytes.ToSize())">
                                             <td>@indexStat.Primaries.Documents.Count.ToComma() <span class="note">(@indexStat.Primaries.Store.SizeInBytes.ToSize()) <span title="@i.NumberOfReplicas.Pluralize("replica")">x@(i.NumberOfReplicas+1)</span></span></td>
                                         </tr>
                                     }
-                                }
                             </tbody>
                         </table>
                     }


### PR DESCRIPTION
When no stats are present for indexes, show the user a nice error message.  
