### PR TITLE
Resolve console error; clarify disabled modal section text

### DIFF
--- a/Opserver/Views/SQL/Databases.Modal.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.cshtml
@@ -59,7 +59,7 @@
 @helper RenderLink(DatabasesModel.Views view, string text, bool disabled = false) {
     if (disabled)
     {
-    <a href="javascript:void()" class="disabled">@text</a>
+    <a href="#" class="disabled">@text (Disabled)</a>
     }
     else
     {


### PR DESCRIPTION
I noticed a console error every time I clicked on the "Views", "Storage", etc. section on an instance view. 

I thought this might have been an issue so I investigated, but it turns out they're just disabled.

I made the following changes:
- Rather than use `javascript:void()` on disabled links, I set them to `href="#"` which has the same effect as far as I can tell, without JavaScript (and the console error).
- I added the text "(Disabled)" to the disabled sections, so that users would be aware that they're disabled rather than thinking there might be an issue (as I did).

I know this isn't as relevant, but thanks for your efforts on this great application.
