### PR TITLE
Fixed UTC Assumptions

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -233,18 +233,21 @@ From sys.databases db
             public string LastFullBackupPhysicalDeviceName { get; internal set; }
 
             internal const string FetchSQL = @"
+DECLARE @UTCOffset int
+SET @UTCOffset = (SELECT DATEDIFF(MI, GETDATE(), GETUTCDATE()))
+
 Select db.database_id Id,
        db.name Name, 
        lb.type LastBackupType,
-       lb.backup_start_date LastBackupStartDate,
-       lb.backup_finish_date LastBackupFinishDate,
+       DATEADD(MI, @UTCOffset,lb.backup_start_date) LastBackupStartDate,
+       DATEADD(MI, @UTCOffset, lb.backup_finish_date) LastBackupFinishDate,
        lb.backup_size LastBackupSizeBytes,
        lb.compressed_backup_size LastBackupCompressedSizeBytes,
        lbmf.device_type LastBackupMediaDeviceType,
        lbmf.logical_device_name LastBackupLogicalDeviceName,
        lbmf.physical_device_name LastBackupPhysicalDeviceName,
-       fb.backup_start_date LastFullBackupStartDate,
-       fb.backup_finish_date LastFullBackupFinishDate,
+       DATEADD(MI, @UTCOffset, fb.backup_start_date) LastFullBackupStartDate,
+       DATEADD(MI, @UTCOffset, fb.backup_finish_date) LastFullBackupFinishDate,
        fb.backup_size LastFullBackupSizeBytes,
        fb.compressed_backup_size LastFullBackupCompressedSizeBytes,
        fbmf.device_type LastFullBackupMediaDeviceType,

--- a/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
@@ -149,8 +149,8 @@ FROM (SELECT TOP (@MaxResultCount)
              qs.sql_handle AS SqlHandle,
 			 Cast(pa.value as Int) DatabaseId
         FROM (SELECT *, 
-                     CAST((CASE WHEN DATEDIFF(second, creation_time, GETDATE()) > 0 And execution_count > 1
-                                THEN DATEDIFF(second, creation_time, GETDATE()) / 60.0
+                     CAST((CASE WHEN DATEDIFF(second, creation_time, GETUTCDATE()) > 0 And execution_count > 1
+                                THEN DATEDIFF(second, creation_time, GETUTCDATE()) / 60.0
                                 ELSE Null END) as MONEY) as age_minutes, 
                      CAST((CASE WHEN DATEDIFF(second, creation_time, last_execution_time) > 0 And execution_count > 1
                                 THEN DATEDIFF(second, creation_time, last_execution_time) / 60.0


### PR DESCRIPTION
The issue was mentioned previously in [pull request 11](https://github.com/opserver/Opserver/pull/11).  Opserver assumes that servers will use UTC time, but the actual SQL code previously return local time.  This fixes two other instances of this issue that haven't yet been addressed.
