### PR TITLE
JSON encode SQL instance name in initialisation call

### DIFF
--- a/Opserver/Content/js/Scripts.js
+++ b/Opserver/Content/js/Scripts.js
@@ -529,7 +529,7 @@ Status.NodeSearch = (function () {
 Status.SQL = (function () {
     
     function loadCluster(val) {
-        var pieces = val.split('/');
+        var pieces = $.map(val.split('/'), function(s) { return decodeURIComponent(s.replace(/\+/g, '%20')); });
         Status.Dashboard.options.refreshData = {
             cluster: pieces.length > 0 ? pieces[0] : null,
             ag: pieces.length > 1 ? pieces[1] : null,

--- a/Opserver/Views/SQL/Dashboard.cshtml
+++ b/Opserver/Views/SQL/Dashboard.cshtml
@@ -14,7 +14,7 @@
     <script>
         $(function() {
             Status.Dashboard.init({ refresh: @(Model.Refresh) });
-            Status.SQL.init({ node: '@(Model.CurrentInstance != null ? Model.CurrentInstance.Name : "")' });
+            Status.SQL.init({ node: @(Json.Encode(Model.CurrentInstance != null ? Model.CurrentInstance.Name : "").AsHtml()) });
         });
     </script>
 }

--- a/Opserver/Views/SQL/Dashboard.cshtml
+++ b/Opserver/Views/SQL/Dashboard.cshtml
@@ -8,7 +8,7 @@
 }
 @helper TabLink(DashboardModel.Views view, string href, string name, bool includeParams = true)
 {
-    <a class="@(Model.View == view ? "selected" : "")" href="@href@(includeParams && Model.CurrentInstance != null ? "?node=" + Model.CurrentInstance.Name : "")">@name</a>
+    <a class="@(Model.View == view ? "selected" : "")" href="@href@(includeParams && Model.CurrentInstance != null ? "?node=" + Model.CurrentInstance.Name.UrlEncode() : "")">@name</a>
 }
 @section head {
     <script>

--- a/Opserver/Views/SQL/Instance.cshtml
+++ b/Opserver/Views/SQL/Instance.cshtml
@@ -93,7 +93,7 @@ else if (i.LastFetch.LastSuccess == null)
                 <tbody>
                     <tr title="@pd.CPUCount.Pluralize("Core") (including hyperthreading) across @pd.CPUSocketCount.Pluralize("Socket")">
                         <td>CPU</td>
-                        <td><a href="/sql/top?node=@i.Name">@(i.CurrentCPUPercent)%</a> <span class="note">(@pd.CPUCount.Pluralize("Core"))</span> <img class="cpu-graph" alt="CPU in the last hour for @i.Name" src="~/graph/sql/cpu/spark?node=@i.Name&time=@DateTime.UtcNow.ToString("yyyy-MM-dd-HH-mm")" /></td>
+                        <td><a href="/sql/top?node=@i.Name">@(i.CurrentCPUPercent)%</a> <span class="note">(@pd.CPUCount.Pluralize("Core"))</span> <img class="cpu-graph" alt="CPU in the last hour for @i.Name" src="~/graph/sql/cpu/spark?node=@i.Name.UrlEncode()&time=@DateTime.UtcNow.ToString("yyyy-MM-dd-HH-mm")" /></td>
                     </tr>
                     @if (pd.VirtualMachineType != VirtualMachineTypes.None)
                     {
@@ -202,7 +202,7 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                         {
                             @:,
                         }
-                        <span title="@cn.ClusterStatus">@cn.IconSpan() <a href="/sql/instance?node=@cn.Name" class="node-name-link @(cn.IsAnAGPrimary ? "bold" : "")">@cn.Name</a></span>
+                        <span title="@cn.ClusterStatus">@cn.IconSpan() <a href="/sql/instance?node=@cn.Name.UrlEncode()" class="node-name-link @(cn.IsAnAGPrimary ? "bold" : "")">@cn.Name</a></span>
                         iter++;
                     }
                 </div>
@@ -266,7 +266,7 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                     {
                         <div class="section-wrap third-wrap">
                             <div class="network-range">@g.Key.NetworkSubnetIP/@g.Key.NetworkSubnetPrefixLength</div>
-                            <div class="network-nodes">@string.Join(", ", g.Select(n => string.Format("<a href=\"/sql/instance?node={0}\" class=\"node-name-link\">{0}</a>", n.MemberName))).AsHtml()</div>
+                            <div class="network-nodes">@string.Join(", ", g.Select(n => string.Format("<a href=\"/sql/instance?node={0}\" class=\"node-name-link\">{0}</a>", n.MemberName.UrlEncode()))).AsHtml()</div>
                         </div>
                     }
                 }
@@ -336,7 +336,7 @@ Avgerage Write Stall: @v.AvgWriteStallMS ms">
                         </tr>
                     </thead>
                     <tbody>
-                        @RenderPerSecCounter("SQL Statistics", "Batch Requests/sec", "", valueUrl: string.Format("/sql/top?node={0}&sort=ExecutionsPerMinute&LastRunSeconds=300", i.Name))
+                        @RenderPerSecCounter("SQL Statistics", "Batch Requests/sec", "", valueUrl: string.Format("/sql/top?node={0}&sort=ExecutionsPerMinute&LastRunSeconds=300", i.Name.UrlEncode()))
                         @RenderPerSecCounter("SQL Statistics", "SQL Compilations/sec", "", toSuffix: v => compPercent.HasValue ? string.Format("({0}%)", compPercent.Value.ToString("##0.##")) : null)
                         @RenderPerSecCounter("SQL Statistics", "SQL Re-Compilations/sec", "")
                         @RenderPerSecCounter("SQL Statistics", "Guided plan executions/sec", "")

--- a/Opserver/Views/SQL/Operations.Top.Detail.cshtml
+++ b/Opserver/Views/SQL/Operations.Top.Detail.cshtml
@@ -88,13 +88,13 @@
                         <td colspan="6" class="value">0x@(op.ReadablePlanHandle) 
                             @if(Current.User.IsSQLAdmin)
                             {
-                                <span class="handle-link">(<a href="/sql/remove-plan?node=@s.Name&handle=@HttpServerUtility.UrlTokenEncode(op.PlanHandle)">remove plan</a>)</span>
+                                <span class="handle-link">(<a href="/sql/remove-plan?node=@s.Name.UrlEncode()&handle=@HttpServerUtility.UrlTokenEncode(op.PlanHandle)">remove plan</a>)</span>
                             }
                         </td>
                     </tr>
                     <tr>
                         <td colspan="2" class="key">Query Plan:</td>
-                        <td colspan="6" class="value"><a href="/sql/top/plan?node=@s.Name&handle=@HttpServerUtility.UrlTokenEncode(op.PlanHandle)" class="blue-dotted">download</a> - <a href="#" class="blue-dotted" onclick="javascript:alert('soon');">view similar</a> - <a href="#/plan/@HttpServerUtility.UrlTokenEncode(op.PlanHandle)" class="blue-dotted">link</a></td>
+                        <td colspan="6" class="value"><a href="/sql/top/plan?node=@s.Name.UrlEncode()&handle=@HttpServerUtility.UrlTokenEncode(op.PlanHandle)" class="blue-dotted">download</a> - <a href="#" class="blue-dotted" onclick="javascript:alert('soon');">view similar</a> - <a href="#/plan/@HttpServerUtility.UrlTokenEncode(op.PlanHandle)" class="blue-dotted">link</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/Opserver/Views/SQL/Servers.cshtml
+++ b/Opserver/Views/SQL/Servers.cshtml
@@ -39,7 +39,7 @@
         {
             <tbody class="node-header" data-name="header-@c.Name">    
                 <tr class="category-row">
-                    <th colspan="12"><h3><a href="~/sql/servers#/cluster/@c.Name" class="node-name-link" data-refresh="5">@c.IconSpan() @c.Name</a> <span class="quorum-info">(@c.QuorumType.GetDescription() - @c.QuorumState.GetDescription())</span></h3></th>
+                    <th colspan="12"><h3><a href="~/sql/servers#/cluster/@c.Name.UrlEncode()" class="node-name-link" data-refresh="5">@c.IconSpan() @c.Name</a> <span class="quorum-info">(@c.QuorumType.GetDescription() - @c.QuorumState.GetDescription())</span></h3></th>
                 </tr>
                 <tr>
                     <th></th>
@@ -65,7 +65,7 @@
                         <td><a href="~/sql/instance?node=@n.Name.UrlEncode()" class="node-name-link">@n.Name</a></td>
                         <td title="Votes: @n.ClusterVotes">@n.ClusterMember.State.GetDescription()</td>
                         <td><a href="~/sql/active?node=@n.Name.UrlEncode()">@(n.ServerInfo != null ? n.ServerInfo.CPUStatusSpan() : null)</a></td>
-                        <td class="sql-cpu-spark"><img alt="CPU in the last hour for @n.Name" src="~/graph/sql/cpu/spark?node=@n.Name" /></td>
+                        <td class="sql-cpu-spark"><img alt="CPU in the last hour for @n.Name" src="~/graph/sql/cpu/spark?node=@n.Name.UrlEncode()" /></td>
                         @MemoryCell(n)
                         <td>@SQLHelpers.HealthDescriptionAGs(n, cAgs)</td>
                         <td>@SQLHelpers.HealthDescription(n, cAgs.Where(ag => ag.LocalReplica != null).SelectMany(ag => ag.LocalReplica.Databases))</td>
@@ -106,7 +106,7 @@
                     <td>@i.IconSpan()</td>
                     <td><a href="~/sql/instance?node=@i.Name.UrlEncode()" class="node-name-link">@i.Name</a></td>
                     <td><a href="~/sql/active?node=@i.Name.UrlEncode()">@(i.CurrentCPUPercent.HasValue ? i.CurrentCPUPercent + "%" : "")</a></td>
-                    <td class="sql-cpu-spark"><img alt="CPU in the last hour for @i.Name" src="~/graph/sql/cpu/spark?node=@i.Name&time=@DateTime.UtcNow.ToString("yyyy-MM-dd")" /></td>
+                    <td class="sql-cpu-spark"><img alt="CPU in the last hour for @i.Name" src="~/graph/sql/cpu/spark?node=@i.Name.UrlEncode()&time=@DateTime.UtcNow.ToString("yyyy-MM-dd")" /></td>
                     @MemoryCell(i)
                     <td title="@dbs.Count Databases:
 @string.Concat(dbs.GroupBy(db => db.OverallStateDescription).Select(g => string.Format("  {0}: {1}\n", g.Key, g.Count().Pluralize("Database"))))">


### PR DESCRIPTION
When using named SQL instances, fixes issues loading further info on SQL pages (e.g. details for query on SQL top query page).

It's just a missing javascript string encode.

I think this will probably also address issue #34.