### PR TITLE
Avoid InvalidOperationException when no traffic in GraphController.NetworkJson()

### DIFF
--- a/Opserver/Controllers/GraphController.Json.cs
+++ b/Opserver/Controllers/GraphController.Json.cs
@@ -80,8 +80,8 @@ namespace StackExchange.Opserver.Controllers
                 {
                     maximums = new
                         {
-                            main_in = traffic.Max(i => (int)i.InAvgBps.GetValueOrDefault(0)),
-                            main_out = traffic.Max(i => (int)i.OutAvgBps.GetValueOrDefault(0))
+                            main_in = traffic.Any() ? traffic.Max(i => (int)i.InAvgBps.GetValueOrDefault(0)) : 0,
+                            main_out = traffic.Any() ? traffic.Max(i => (int)i.OutAvgBps.GetValueOrDefault(0)) : 0
                         },
                     points = traffic.Select(i => new 
                         {


### PR DESCRIPTION
In `GraphController.NetworkJson` if the `GetUtilization` method returns an empty list for `traffic`, an `InvalidOperationException` will be thrown when generating the Json method, due to running `Max` on an empty list. This PR avoids the issue.
