### PR TITLE
Use pointers in clickable tables in the Sql > Databases section

### DIFF
--- a/Opserver/Content/_Styles.SQL.less
+++ b/Opserver/Content/_Styles.SQL.less
@@ -300,7 +300,12 @@
         .sql-tables {
             background-color: white;
         }
-    }    
+    }   
+    &#databases-table tr, &#database-table tr{
+        th, td {
+            cursor:pointer;
+        }
+    }
 }
 
 .node-selector {


### PR DESCRIPTION
Tables in Sql > Databases (both the table listing the databases in a server, and the table listing the tables in a database) have clickable cells (to show detail) and headers (to sort). This makes the cursor into a pointer when hovering over these tables (so that the user knows that it is clickable).
