### PR TITLE
Allow sockets as a valid type for HAProxy

### DIFF
--- a/Opserver.Core/Data/HAProxy/Item.cs
+++ b/Opserver.Core/Data/HAProxy/Item.cs
@@ -399,8 +399,10 @@ namespace StackExchange.Opserver.Data.HAProxy
                     return new Backend();
                 case StatusType.Server:
                     return new Server();
+                case StatusType.Socket:
+                    return new Socket();
                 default:
-                    throw new NotImplementedException("What the hell are you using sockets for?");
+                    throw new NotImplementedException("Unrecognized StatusType " + typeNum);
             }
         }
 


### PR DESCRIPTION
We use sockets in our HAProxy.  This commit allows them to be shown and avoids throwing an exception.
