### PR TITLE
Add WMI Data Provider

### DIFF
--- a/Opserver.Core/Data/Dashboard/DashboardData.cs
+++ b/Opserver.Core/Data/Dashboard/DashboardData.cs
@@ -34,6 +34,9 @@ namespace StackExchange.Opserver.Data.Dashboard
                     case "orion":
                         _dataProviders.Add(new OrionDataProvider(p));
                         break;
+                    case "wmi":
+                        _dataProviders.Add(new WmiDataProvider(p));
+                        break;
                     // moar providers, feed me!
                 }
             }

--- a/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Data.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Data.cs
@@ -1,0 +1,262 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace StackExchange.Opserver.Data.Dashboard.Providers
+{
+    partial class WmiDataProvider
+    {
+        /// <summary>
+        /// Contains node's data and stores utilizastion history
+        /// (as soon as WMI provider doens't has orion storage...)
+        /// </summary>
+        private class WmiNode
+        {
+            private readonly Dictionary<string, List<Interface.InterfaceUtilization>> _netUtilization;
+
+            internal readonly List<Interface> Interfaces;
+
+            internal readonly List<Node.MemoryUtilization> MemoryUtilization;
+
+            internal readonly List<Node.CPUUtilization> CpuUtilization;
+
+            internal readonly List<Volume> Volumes;
+
+            internal int Id { get { return Node.Id; } }
+
+            internal Node Node { get; private set; }
+
+            /// <summary>
+            /// Name as specified in WmiProviderSettings.json.
+            /// Real name can be different, like for localhost, for example.
+            /// </summary>
+            internal string OriginalName { get; set; }
+
+            internal List<Cache> Caches { get; private set; }
+            
+            internal WmiProviderSettings Config { get; set; }
+
+            public WmiNode(Node node)
+            {
+                Caches = new List<Cache>(2);
+                _netUtilization = new Dictionary<string, List<Interface.InterfaceUtilization>>(2);
+                Interfaces = new List<Interface>(2);
+                MemoryUtilization = new List<Node.MemoryUtilization>(1024);
+                CpuUtilization = new List<Node.CPUUtilization>(1024);
+                Volumes = new List<Volume>(3);
+
+                Node = node;
+            }
+
+            public void AddNetworkUtilization(Interface iface, Interface.InterfaceUtilization item)
+            {
+                if (iface == null)
+                    return;
+
+                var ownIface = Interfaces.FirstOrDefault(x => x == iface);
+                if (ownIface == null)
+                    return;
+
+                List<Interface.InterfaceUtilization> data;
+                if (!_netUtilization.ContainsKey(ownIface.Name))
+                {
+                    data = new List<Interface.InterfaceUtilization>(1024);
+                    _netUtilization[ownIface.Name] = data;
+                }
+                else
+                {
+                    data = _netUtilization[ownIface.Name];
+                }
+
+                if (!item.InAvgBps.HasValue)
+                {
+                    item.InAvgBps = item.InMaxBps;
+                }
+                if (!item.OutAvgBps.HasValue)
+                {
+                    item.OutAvgBps = item.OutMaxBps;
+                }
+
+                if (iface.Speed.HasValue && iface.Speed.Value > 0)
+                {
+                    item.MaxLoad = (short)(100*(item.InMaxBps + item.OutMaxBps)/iface.Speed);
+                    item.AvgLoad = (short)(100*(item.InAvgBps + item.OutAvgBps)/iface.Speed);
+                }
+                
+                UpdateHistoryStorage(data, item, x => x.DateTime);
+            }
+
+
+            internal List<Interface.InterfaceUtilization> GetInterfaceUtilizationHistory(Interface @interface)
+            {
+                List<Interface.InterfaceUtilization> result;
+                if (@interface != null 
+                    && Interfaces.FirstOrDefault(x => x == @interface) != null
+                    && _netUtilization.ContainsKey(@interface.Name))
+                {
+                    result = _netUtilization[@interface.Name];
+                }
+                else
+                {
+                    result = new List<Interface.InterfaceUtilization>(0);
+                }
+                return result;
+            }
+
+            public void AddCpuUtilization(Node.CPUUtilization cpuUtilization)
+            {
+                UpdateHistoryStorage(CpuUtilization, cpuUtilization, x => x.DateTime);
+            }
+
+            public void AddMemoryUtilization(Node.MemoryUtilization utilization)
+            {
+                UpdateHistoryStorage(MemoryUtilization, utilization, x => x.DateTime);
+            }
+
+            private void UpdateHistoryStorage<T>(List<T> data, T newItem, Func<T, DateTime> getDate)
+            {
+                lock (data)
+                {
+                    data.Add(newItem);
+
+                    if (data.Count%100 != 0)
+                        return;
+
+                    var limit = DateTime.UtcNow.AddHours(-Config.HoursToKeepHistory);
+                    if (getDate(data[0]) >= limit)
+                        return;
+ 
+                    var index = data.FindIndex(x => getDate(x) >= limit);
+                    if (index <= 0)
+                        return;
+
+                    data.RemoveRange(0, index + 1);
+                }
+            }
+        }
+
+        public override IEnumerable<Node.CPUUtilization> GetCPUUtilization(Node node, DateTime? start, DateTime? end, int? pointCount = null)
+        {
+            var wNode = _wmiNodes.FirstOrDefault(x => x.Id == node.Id);
+            if (wNode == null)
+                return Enumerable.Empty<Node.CPUUtilization>();
+
+            Node.CPUUtilization startVal = null;
+            if (start.HasValue)
+            {
+                startVal = new Node.CPUUtilization { DateTime = start.Value };
+            }
+            Node.CPUUtilization endVal = null;
+            if (end.HasValue)
+            {
+                endVal = new Node.CPUUtilization { DateTime = end.Value };
+            }
+            return FilterHistory(wNode.CpuUtilization, startVal, endVal, new CpuUtilComparer());
+        }
+
+        class CpuUtilComparer : IComparer<Node.CPUUtilization>
+        {
+            public int Compare(Node.CPUUtilization x, Node.CPUUtilization y)
+            {
+                return x.DateTime.CompareTo(y.DateTime);
+            }
+        }
+
+        class MemoryUtilComparer : IComparer<Node.MemoryUtilization>
+        {
+            public int Compare(Node.MemoryUtilization x, Node.MemoryUtilization y)
+            {
+                return x.DateTime.CompareTo(y.DateTime);
+            }
+        }
+
+        class InterfaceUtilComparer : IComparer<Interface.InterfaceUtilization>
+        {
+            public int Compare(Interface.InterfaceUtilization x, Interface.InterfaceUtilization y)
+            {
+                return x.DateTime.CompareTo(y.DateTime);
+            }
+        }
+
+        private static IEnumerable<T> FilterHistory<T>(List<T> list, T start, T end, IComparer<T> comparer = null)
+            where T: class
+        {
+            lock (list)
+            {
+                var startIndex = 0;
+                var endIndex = list.Count;
+
+                if (start != null)
+                {
+                    var index = list.BinarySearch(start, comparer);
+                    if (index < 0)
+                    {
+                        index = ~index;
+                    }
+                    startIndex = Math.Min(index, endIndex);
+                }
+                if (end != null)
+                {
+                    var index = list.BinarySearch(end, comparer);
+                    if (index < 0)
+                    {
+                        index = ~index;
+                    }
+                    endIndex = Math.Min(index+1, endIndex);
+                }
+                var sliceLength = endIndex - startIndex;
+                return sliceLength <= 0 
+                    ? Enumerable.Empty<T>() 
+                    : list.Skip(startIndex).Take(sliceLength).ToList();
+            }
+        }
+
+        public override IEnumerable<Node.MemoryUtilization> GetMemoryUtilization(Node node, DateTime? start, DateTime? end, int? pointCount = null)
+        {
+            var wNode = _wmiNodes.FirstOrDefault(x => x.Id == node.Id);
+            if (wNode == null)
+                return Enumerable.Empty<Node.MemoryUtilization>();
+
+            Node.MemoryUtilization startVal = null;
+            if (start.HasValue)
+            {
+                startVal = new Node.MemoryUtilization { DateTime = start.Value };
+            }
+            Node.MemoryUtilization endVal = null;
+            if (end.HasValue)
+            {
+                endVal = new Node.MemoryUtilization { DateTime = end.Value };
+            }
+            return FilterHistory(wNode.MemoryUtilization, startVal, endVal, new MemoryUtilComparer());
+        }
+
+        public override IEnumerable<Volume.VolumeUtilization> GetUtilization(Volume volume, DateTime? start, DateTime? end, int? pointCount = null)
+        {
+            yield break;
+        }
+
+        public override IEnumerable<Interface.InterfaceUtilization> GetUtilization(Interface @interface, DateTime? start, DateTime? end, int? pointCount = null)
+        {
+            var node = _wmiNodes.FirstOrDefault(x => x.Id == @interface.NodeId);
+            if (node == null)
+            {
+                return Enumerable.Empty<Interface.InterfaceUtilization>();
+            }
+
+            var history = node.GetInterfaceUtilizationHistory(@interface);
+
+            Interface.InterfaceUtilization startVal = null;
+            if (start.HasValue)
+            {
+                startVal = new Interface.InterfaceUtilization { DateTime = start.Value };
+            }
+            Interface.InterfaceUtilization endVal = null;
+            if (end.HasValue)
+            {
+                endVal = new Interface.InterfaceUtilization { DateTime = end.Value };
+            }
+            return FilterHistory(history, startVal, endVal, new InterfaceUtilComparer());
+        }
+    }
+}

--- a/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Linq;
+using System.Management;
+using System.Runtime.InteropServices;
+using StackExchange.Opserver.Monitoring;
+
+namespace StackExchange.Opserver.Data.Dashboard.Providers
+{
+    partial class WmiDataProvider
+    {
+        private Node GetDynamicData(WmiNode wmiNode)
+        {
+            try
+            {
+                PollCpuUtilization(wmiNode);
+                PollMemoryUtilization(wmiNode);
+                PollNetworkUtilization(wmiNode);
+            }
+            catch (COMException e)
+            {
+                Current.LogException(e);
+                wmiNode.Node.Status = NodeStatus.Unreachable;
+            }
+            return wmiNode.Node;
+        }
+
+        private Node GetStaticData(WmiNode wmiNode)
+        {
+            try
+            {
+                UpdateNodeData(wmiNode.Node);
+                GetAllVolumes(wmiNode);
+                GetAllInterfaces(wmiNode);
+            }
+            catch (COMException e)
+            {
+                Current.LogException(e);
+                wmiNode.Node.Status = NodeStatus.Unreachable;
+            }
+            return wmiNode.Node;
+        }
+
+        private void PollMemoryUtilization(WmiNode wmiNode)
+        {
+            var node = wmiNode.Node;
+
+            const string query = @"select 
+                AvailableKBytes 
+                from Win32_PerfFormattedData_PerfOS_Memory";
+
+            using (var q = Wmi.Query(node.Name, query))
+            {
+                var data = q.GetFirstResult();
+                if (data == null)
+                    return;
+
+                var available = data.AvailableKBytes * 1024;
+                node.MemoryUsed = node.TotalMemory - available;
+                var utilization = new Node.MemoryUtilization
+                {
+                    DateTime = DateTime.UtcNow,
+                    MaxMemoryUsed = node.MemoryUsed,
+                    AvgMemoryUsed = node.MemoryUsed
+                };
+                wmiNode.AddMemoryUtilization(utilization);
+            }
+        }
+
+        private void PollCpuUtilization(WmiNode wmiNode)
+        {
+            var node = wmiNode.Node;
+
+            const string query = @"select 
+                PercentProcessorTime 
+                from Win32_PerfFormattedData_PerfOS_Processor
+                where Name = '_Total'";
+
+            using (var q = Wmi.Query(node.Name, query))
+            {
+                var data = q.GetFirstResult();
+                if (data == null)
+                    return;
+
+                node.CPULoad = (short)data.PercentProcessorTime;
+                var cpuUtilization = new Node.CPUUtilization
+                {
+                    DateTime = DateTime.UtcNow,
+                    MaxLoad = node.CPULoad,
+                    AvgLoad = node.CPULoad
+                };
+                wmiNode.AddCpuUtilization(cpuUtilization);
+            }
+        }
+
+        private void UpdateNodeData(Node node)
+        {
+            UpdateOsData(node);
+            UpdateComputerData(node);
+
+            node.LastSync = DateTime.UtcNow;
+            node.Status = NodeStatus.Active;
+        }
+
+        private static void UpdateComputerData(Node node)
+        {
+            const string machineQuery = @"select 
+                DNSHostName,
+                Manufacturer,
+                Model
+                from Win32_ComputerSystem";
+            using (var q = Wmi.Query(node.Name, machineQuery))
+            {
+                var data = q.GetFirstResult();
+                if (data == null)
+                    return;
+                node.Model = data.Model;
+                node.Manufacturer = data.Manufacturer;
+                node.Name = data.DNSHostName;
+            }
+        }
+
+        private static void UpdateOsData(Node node)
+        {
+            const string query = @"select 
+                Caption,
+                LastBootUpTime,
+                Version,
+                FreePhysicalMemory,
+                TotalVisibleMemorySize
+                from Win32_OperatingSystem";
+
+            using (var q = Wmi.Query(node.Name, query))
+            {
+                var data = q.GetFirstResult();
+                if (data == null)
+                    return;
+                node.LastBoot = ManagementDateTimeConverter.ToDateTime(data.LastBootUpTime);
+                node.TotalMemory = data.TotalVisibleMemorySize * 1024;
+                node.MemoryUsed = node.TotalMemory - data.FreePhysicalMemory * 1024;
+                node.MachineType = data.Caption.ToString() + " " + data.Version.ToString();
+            }
+        }
+
+        private void PollNetworkUtilization(WmiNode node)
+        {
+            const string queryTemplate = @"select 
+                BytesReceivedPersec,
+                BytesSentPersec,
+                PacketsReceivedPersec,
+                PacketsSentPersec
+                FROM Win32_PerfFormattedData_Tcpip_NetworkInterface where name = '{name}'";
+
+            foreach (var iface in node.Interfaces)
+            {
+                var perfCounterName = iface.Name;
+                //adjust performance counter special symbols for instance name.
+                perfCounterName = perfCounterName.Replace("\\", "_");
+                perfCounterName = perfCounterName.Replace("/", "_");
+                perfCounterName = perfCounterName.Replace("(", "[");
+                perfCounterName = perfCounterName.Replace(")", "]");
+                perfCounterName = perfCounterName.Replace("#", "_");
+
+                var query = queryTemplate.Replace("{name}", perfCounterName);
+                using (var q = Wmi.Query(node.Node.Name, query))
+                {
+                    var data = q.GetFirstResult();
+                    if (data == null)
+                        continue;
+
+                    iface.InBps = data.BytesReceivedPersec;
+                    iface.OutBps = data.BytesSentPersec;
+                    iface.InPps = data.PacketsReceivedPersec;
+                    iface.OutPps = data.PacketsSentPersec;
+
+                    node.AddNetworkUtilization(iface, new Interface.InterfaceUtilization
+                    {
+                        DateTime = DateTime.UtcNow,
+                        InMaxBps = iface.InBps,
+                        OutMaxBps = iface.OutBps
+                    });
+                }
+            }
+        }
+
+        private void GetAllInterfaces(WmiNode node)
+        {
+            const string query = @"SELECT 
+                NetConnectionID,
+                Description,
+                Name,
+                MACAddress,
+                Speed
+                FROM Win32_NetworkAdapter
+                WHERE NetConnectionStatus = 2"; //connected adapters.
+            //'AND PhysicalAdapter = True' causes exceptions with old windows versions.
+
+            using (var q = Wmi.Query(node.Node.Name, query))
+            {
+                foreach (var data in q.GetDynamicResult())
+                {
+                    string name = data.Name;
+                    var i = node.Interfaces.FirstOrDefault(x => x.Name == name);
+                    if (i == null)
+                    {
+                        i = new Interface();
+                        node.Interfaces.Add(i);
+                    }
+
+                    i.Alias = "!alias";
+                    i.Caption = data.NetConnectionID;
+                    i.DataProvider = this;
+                    i.FullName = data.Description;
+                    i.IfName = data.Name;
+                    i.Id = node.Id*10000 + node.Interfaces.Count + 1;
+                    i.NodeId = node.Id;
+                    i.Index = 0;
+                    i.IsTeam = false;
+                    i.LastSync = DateTime.UtcNow;
+                    i.Name = data.Name;
+                    i.NodeId = node.Id;
+                    i.PhysicalAddress = data.MACAddress;
+                    i.Speed = data.Speed;
+                    i.Status = NodeStatus.Active;
+                    i.TypeDescription = "";
+                }
+            }
+        }
+
+        private void GetAllVolumes(WmiNode node)
+        {
+            const string query = @"SELECT 
+                Caption,
+                Description,
+                FreeSpace,
+                Name,
+                Size,
+                VolumeSerialNumber
+                FROM Win32_LogicalDisk
+            WHERE  DriveType = 3"; //fixed disks
+
+            using (var q = Wmi.Query(node.Node.Name, query))
+            {
+                foreach (var disk in q.GetDynamicResult())
+                {
+                    var serial = disk.VolumeSerialNumber;
+                    var v = node.Volumes.FirstOrDefault(x => x.Caption == serial);
+                    if (v == null)
+                    {
+                        v = new Volume();
+                        node.Volumes.Add(v);
+                    }
+
+                    v.Id = node.Id * 20000 + node.Volumes.Count + 1;
+                    v.Available = disk.FreeSpace;
+                    v.Caption = disk.VolumeSerialNumber;
+                    v.Description = disk.Name + " - " + disk.Description;
+                    v.DataProvider = this;
+                    v.Name = disk.Name;
+                    v.NodeId = node.Id;
+                    v.Size = disk.Size;
+                    v.Type = "Fixed Disk";
+                    v.Status = NodeStatus.Active;
+                    v.Used = v.Size - v.Available;
+                    if (v.Size > 0)
+                    {
+                        v.PercentUsed = (float) (100*v.Used/v.Size);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace StackExchange.Opserver.Data.Dashboard.Providers
+{
+    partial class WmiDataProvider : DashboardDataProvider
+    {
+        private readonly WmiProviderSettings _config;
+        private List<WmiNode> _wmiNodes;
+
+        public WmiDataProvider(DashboardSettings.Provider provider)
+            : base(provider)
+        {
+            _config = Current.Settings.GetSettings<WmiProviderSettings>();
+            _wmiNodes = InitNodeList(_config.Nodes).OrderBy(x => x.OriginalName).ToList();
+            _config.Changed += OnConfigChanged;
+        }
+
+        private void OnConfigChanged(object sender, EventArgs eventArgs)
+        {
+            var added = new List<string>();
+            var notChanged = new List<WmiNode>();
+
+            //Determine added, removed and not changes nodes.
+            FindChanges(_wmiNodes, _config.Nodes.OrderBy(x => x).ToList(), added, notChanged);
+
+            //Init new list.
+            var addedNodes = InitNodeList(added, _wmiNodes.Max(x => x.Id) + 1);
+            var newNodeList = notChanged.Concat(addedNodes).OrderBy(x => x.OriginalName).ToList();
+            _wmiNodes = newNodeList;
+        }
+
+        /// <summary>
+        /// Find config changes. Lists should be sorded ascending.
+        /// </summary>
+        /// <param name="existingWmiNodes">Current wmi nodes list.</param>
+        /// <param name="configNodeNames">Config node names to be checked for new/removed nodes.</param>
+        /// <param name="added">New config names go here.</param>
+        /// <param name="notChanged">WmiNode list items which should remain.</param>
+        private static void FindChanges(
+            IReadOnlyList<WmiNode> existingWmiNodes,
+            IReadOnlyList<string> configNodeNames,
+            ICollection<string> added,
+            ICollection<WmiNode> notChanged)
+        {
+            var existingIndex = 0;
+            var configIndex = 0;
+
+            while (existingIndex < existingWmiNodes.Count && configIndex < configNodeNames.Count)
+            {
+                var existingWmiNode = existingWmiNodes[existingIndex];
+                var configNodeName = configNodeNames[configIndex];
+                var eq = String.Compare(existingWmiNode.OriginalName, configNodeName, StringComparison.OrdinalIgnoreCase);
+                if (eq < 0)
+                {
+                    //left item less than right. which means that it has to be removed.
+                    existingIndex++;
+                }
+                else if (eq > 0)
+                {
+                    //right item is less, add it.
+                    added.Add(configNodeName);
+                    configIndex++;
+                }
+                else //equal
+                {
+                    //No changes, increase both indexes;
+                    notChanged.Add(existingWmiNode);
+                    existingIndex++;
+                    configIndex++;
+                }
+            }
+            if (existingIndex >= existingWmiNodes.Count) //Reached end of left array. 
+            {
+                //Now all items from right array are to be added
+                while (configIndex < configNodeNames.Count)
+                {
+                    added.Add(configNodeNames[configIndex++]);
+                }
+            }
+            //No need to track removed explicityly here.
+        }
+
+        /// <summary>
+        /// Make list of nodes as per configuration. 
+        /// When adding, a node's ip address is resolved via Dns.
+        /// </summary>
+        private IEnumerable<WmiNode> InitNodeList(IList<string> names, int startId = 1)
+        {
+            var nodesList = new List<WmiNode>(names.Count());
+            var id = startId;
+            foreach (var nodeName in names)
+            {
+                var node = new Node
+                {
+                    Id = id++,
+                    Name = nodeName.ToLower(),
+                    DataProvider = this,
+                    MachineType = "Windows",
+                };
+
+                try
+                {
+                    var hostEntry = Dns.GetHostEntry(node.Name);
+                    if (hostEntry.AddressList.Any())
+                    {
+                        node.Ip = hostEntry.AddressList[0].ToString();
+                        node.Status = NodeStatus.Active;
+                    }
+                    else
+                    {
+                        node.Status = NodeStatus.Unreachable;
+                    }
+                }
+                catch (Exception)
+                {
+                    node.Status = NodeStatus.Unreachable;
+                }
+
+                var wmiNode = new WmiNode(node)
+                {
+                    OriginalName = nodeName,
+                    Config = _config
+                };
+
+                var staticDataCache = ProviderCache(
+                    () => GetStaticData(wmiNode), 
+                    _config.StaticDataTimeoutSec,
+                    memberName: wmiNode.Node.Name + "-Static");
+                wmiNode.Caches.Add(staticDataCache);
+                wmiNode.Caches.Add(ProviderCache(
+                    () => GetDynamicData(wmiNode), 
+                    _config.DynamicDataTimeoutSec,
+                    memberName: wmiNode.Node.Name + "-Dynamic"));
+
+                //Force update static host data, incuding os info, volumes, interfaces.
+                staticDataCache.Poll(true);
+
+                nodesList.Add(wmiNode);
+            }
+            return nodesList;
+        }
+
+        public override int MinSecondsBetweenPolls
+        {
+            get { return 10; }
+        }
+
+        public override string NodeType
+        {
+            get { return "WMI"; }
+        }
+
+        public override IEnumerable<Cache> DataPollers
+        {
+            get
+            {
+                return _wmiNodes.SelectMany(x => x.Caches);
+            }
+        }
+
+        protected override IEnumerable<MonitorStatus> GetMonitorStatus()
+        {
+            yield break;
+        }
+
+        protected override string GetMonitorStatusReason()
+        {
+            return null;
+        }
+
+        public override bool HasData
+        {
+            get { return DataPollers.Any(x => x.HasData()); }
+        }
+
+        public override List<Node> AllNodes
+        {
+            get { return _wmiNodes.Select(w => w.Node).ToList(); }
+        }
+
+        public override List<Interface> AllInterfaces
+        {
+            get { return _wmiNodes.SelectMany(w => w.Interfaces).ToList(); }
+        }
+
+        public override List<Volume> AllVolumes
+        {
+            get { return _wmiNodes.SelectMany(w => w.Volumes).ToList(); }
+        }
+
+        public override List<Application> AllApplications
+        {
+            get { return new List<Application>(); }
+        }
+
+        public override IEnumerable<Node> GetNodesByIP(IPAddress ip)
+        {
+            yield break;
+        }
+
+        public override IEnumerable<IPAddress> GetIPsForNode(Node node)
+        {
+            yield break;
+        }
+    }
+}

--- a/Opserver.Core/Monitoring/Wmi.cs
+++ b/Opserver.Core/Monitoring/Wmi.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Dynamic;
+using System.Linq;
+using System.Management;
+
+namespace StackExchange.Opserver.Monitoring
+{
+    internal static class Wmi
+    {
+        internal static WmiQuery Query(string machineName, string query)
+        {
+            return new WmiQuery(machineName, query);
+        }
+
+        private static ConnectionOptions GetConnectOptions(string machineName)
+        {
+            var co = new ConnectionOptions();
+            if (machineName == Environment.MachineName)
+                return co;
+
+            switch (machineName)
+            {
+                case "localhost":
+                case "127.0.0.1":
+                case "::1":
+                    return co;
+                default:
+                    co = new ConnectionOptions
+                    {
+                        Authentication = AuthenticationLevel.Packet,
+                        Timeout = new TimeSpan(0, 0, 30),
+                        EnablePrivileges = true
+                    };
+                    break;
+            }
+            var wps = Current.Settings.Polling.Windows;
+            if (wps != null && wps.AuthUser.HasValue() && wps.AuthPassword.HasValue())
+            {
+                co.Username = wps.AuthUser;
+                co.Password = wps.AuthPassword;
+            }
+            return co;
+        }
+
+        internal class WmiQuery : IDisposable
+        {
+            ManagementObjectCollection _data;
+            ManagementObjectSearcher _searcher;
+
+            public WmiQuery(string machineName, string q)
+            {
+                if (string.IsNullOrEmpty(machineName))
+                    throw new ArgumentException("machineName should not be empty.");
+
+                var connectionOptions = GetConnectOptions(machineName);
+                var scope = new ManagementScope(string.Format(@"\\{0}\root\cimv2", machineName), connectionOptions);
+                _searcher = new ManagementObjectSearcher(scope, new ObjectQuery(q), new EnumerationOptions{Timeout = connectionOptions.Timeout});
+            }
+
+            public ManagementObjectCollection Result
+            {
+                get
+                {
+                    if (_searcher == null)
+                    {
+                        throw new InvalidOperationException("Attempt to use disposed query.");
+                    }
+                    return _data ?? (_data = _searcher.Get());
+                }
+            }
+
+            public IEnumerable<dynamic> GetDynamicResult()
+            {
+                return Result.Cast<ManagementObject>().Select(mo => new WmiDynamic(mo));
+            }
+
+            public dynamic GetFirstResult()
+            {
+                var obj = Result.Cast<ManagementObject>().FirstOrDefault();
+                return obj == null ? null : new WmiDynamic(obj);
+            }
+
+            public void Dispose()
+            {
+                if (_data != null)
+                {
+                    _data.Dispose();
+                    _data = null;
+                }
+                if (_searcher != null)
+                {
+                    _searcher.Dispose();
+                    _searcher = null;
+                }
+            }
+        }
+
+        class WmiDynamic : DynamicObject
+        {
+            readonly ManagementObject _obj;
+            public WmiDynamic(ManagementObject obj)
+            {
+                _obj = obj;
+            }
+
+            public override bool TryGetMember(GetMemberBinder binder, out object result)
+            {
+                try
+                {
+                    result = _obj.Properties[binder.Name].Value;
+                    return true;
+                }
+                catch (ManagementException)
+                {
+                    result = null;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/Opserver.Core/Opserver.Core.csproj
+++ b/Opserver.Core/Opserver.Core.csproj
@@ -134,6 +134,13 @@
     <Compile Include="Data\Dashboard\Providers\OrionDataProvider.Volumes.cs">
       <DependentUpon>OrionDataProvider.cs</DependentUpon>
     </Compile>
+    <Compile Include="Data\Dashboard\Providers\WmiDataProvider.cs" />
+    <Compile Include="Data\Dashboard\Providers\WmiDataProvider.Data.cs">
+      <DependentUpon>WmiDataProvider.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Data\Dashboard\Providers\WmiDataProvider.Polling.cs">
+      <DependentUpon>WmiDataProvider.cs</DependentUpon>
+    </Compile>
     <Compile Include="Data\DataProvider.cs" />
     <Compile Include="Data\Elastic\ElasticCluster.Actions.cs">
       <DependentUpon>ElasticCluster.cs</DependentUpon>
@@ -325,6 +332,7 @@
     <Compile Include="Data\SQL\SQLNode.TCPListeners.cs">
       <DependentUpon>SQLNode.cs</DependentUpon>
     </Compile>
+    <Compile Include="Monitoring\Wmi.cs" />
     <Compile Include="OpserverCore.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings\DashboardSettings.cs" />
@@ -342,6 +350,7 @@
     <Compile Include="Settings\SettingsSection.cs" />
     <Compile Include="Settings\SQLSettings.cs" />
     <Compile Include="Settings\TeamCitySettings.cs" />
+    <Compile Include="Settings\WmiProviderSettings.cs" />
     <Compile Include="StringSplits.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Opserver.Core/Settings/WmiProviderSettings.cs
+++ b/Opserver.Core/Settings/WmiProviderSettings.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace StackExchange.Opserver
+{
+    /// <summary>
+    /// Settings for WmiDataProvider are in the form:
+    /// nodes["name1", "name2", ..., "nameN"]
+    /// </summary>
+    public class WmiProviderSettings : Settings<WmiProviderSettings>
+    {
+        public override bool Enabled { get { return Nodes.Any(); } }
+
+        public List<string> Nodes { get; set; }
+        
+        /// <summary>
+        /// Timeout in seconds for cache with more or less static data,
+        /// like node name or volume size.
+        /// </summary>
+        public int StaticDataTimeoutSec { get; set; }
+        
+        /// <summary>
+        /// Timeout in seconds for dynamic data like CPU load.
+        /// </summary>
+        public int DynamicDataTimeoutSec { get; set; }
+
+        public int HoursToKeepHistory { get; set; }
+
+        public WmiProviderSettings()
+        {
+            Nodes = new List<string>();
+            StaticDataTimeoutSec = 60*5;
+            DynamicDataTimeoutSec = 5;
+            HoursToKeepHistory = 2;
+        }
+    }
+}

--- a/Opserver/Config/WmiProviderSettings.json.example
+++ b/Opserver/Config/WmiProviderSettings.json.example
@@ -1,0 +1,6 @@
+﻿{
+    nodes:  [ "localhost" ],
+    StaticDataTimeoutSec: 300,
+    DynamicDataTimeoutSec: 5,
+    HoursToKeepHistory: 2
+}


### PR DESCRIPTION
Sample WMI provider for those who want to see at least something at Dashboard.

- WmiDataProvider class queries remote machines via WMI directly.
- Configuration as per additional config "~/Config/WmiProviderSettings.json". Nodes list reloaded automatically when config file changed.
- There are two types of WMI queries - "static" (data which rarely changes like OS version) and "dynamic" (frquently changing metrics like CPU utilization). Each has out configurable cache timeout.
- WMI authentication uses the same config as monitoring, i.e. PollingSettings.json.
- Utilization history is stored directly in memory for two hours (as we work directly with WMI, no Orion).

Sample WmiProviderSettings.json config:
{
    nodes:  [ "localhost" ],
    StaticDataTimeoutSec: 300,
    DynamicDataTimeoutSec: 5,
    HoursToKeepHistory: 2
}