### PR TITLE
Fixes Issue 50. Instance.Configuration.cshtml had a Build Action of None...

### DIFF
--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -300,9 +300,9 @@
     <Content Include="Views\SQL\Databases.Modal.Tables.Columns.cshtml" />
     <Content Include="Views\CloudFlare\DNS.cshtml" />
     <Content Include="Views\SQL\Instance.DBFiles.cshtml" />
-    <None Include="Views\SQL\Instance.Configuration.cshtml">
+    <Content Include="Views\SQL\Instance.Configuration.cshtml">
       <DependentUpon>Instance.cshtml</DependentUpon>
-    </None>
+    </Content>
     <Compile Include="Views\SQL\Ops.Top.Detail.Model.cs">
       <DependentUpon>Operations.Top.Detail.cshtml</DependentUpon>
     </Compile>


### PR DESCRIPTION
..., which meant the file was not copied if you published the site. Changed the Build Action to Content.

Symptom: When viewing a SQL Instance, clicking the "View Configuration" link did nothing.

I had configured my project to publish via VS. After disabling custom errors to see what the issue was, I saw that MVC was not able to find the Instance.Configuration view. Looking in my published Views directory, Instance.Configuration.cshtml was not present.

Fix: In Opserver.csproj, Instance.Configuration.cshtml's Build Action was set to None. I changed it to "Content" so that when I publish my site, the file is copied as expected.

Result: the "View Configuration" link now opens a modal.