### PR TITLE
Dashboard refresh not replacing html.

### DIFF
--- a/Opserver/Content/js/Scripts.js
+++ b/Opserver/Content/js/Scripts.js
@@ -362,6 +362,7 @@ Status.Dashboard = (function () {
                     data: $.extend({}, Status.Dashboard.options.refreshData),
                     cache: false
                 }).done(function (html) {
+                    html = $('<div/>').append(html);
                     var serverGroups = $('.node-group[data-name], .node-header[data-name], .refresh-group[data-name]', html);
                     $('.node-group[data-name], .node-header[data-name], .refresh-group[data-name]').each(function () {
                         var name = $(this).data('name'),


### PR DESCRIPTION
I have been testing the changes in pull request #70 (which is working well for me - hope to have this running in our opserver version this week) and I noticed that the dashboard html was not getting replaced with the response from the server.

Looking into it some more I saw it was not matching the server data-name attributes and giving the error "Unable to find: XXX" in the console log.

The jQuery selector in line 366 was not matching in the html because the selectors get the descendants. The fix wraps the html response in a div and the selectors match the correct elements.