### PR TITLE
Don't add JIRA comment if there is no content

### DIFF
--- a/Opserver.Core/Data/Jira/JiraClient.cs
+++ b/Opserver.Core/Data/Jira/JiraClient.cs
@@ -107,7 +107,11 @@ namespace StackExchange.Opserver.Data.Jira
                 + RenderVariableTable("Cookies", error.Cookies)
                 + RenderVariableTable("RequestHeaders", error.RequestHeaders);
 
-            var commentReponse = await Comment(action, result, commentBody).ConfigureAwait(false);
+            if (!String.IsNullOrWhiteSpace(commentBody))
+            {
+                var commentReponse = await Comment(action, result, commentBody).ConfigureAwait(false);
+            }
+            
             result.Host = GetHost(action);
             return result;
         }


### PR DESCRIPTION
Check if there is any content for the comment before posting it. If the comment's content is empty, JIRA will return a 400 and the user gets an error message for failing to create the comment (even though the JIRA issue was successfully created).

The scenario that this would happen in is when trying to create a JIRA issue with exceptions that do not include the HTTP server variables (query string, form, cookies, request headers, etc).