### PR TITLE
Added regex to parse SQLInstance Object Name from connection string

### DIFF
--- a/Opserver.Core/ExtensionMethods.cs
+++ b/Opserver.Core/ExtensionMethods.cs
@@ -64,6 +64,17 @@ namespace StackExchange.Opserver
         }
 
         /// <summary>
+        /// Returns result of <paramref name="action"/> when this String is null/empty.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="action"></param>
+        /// <returns></returns>
+        public static string IsNullOrEmptyReturn(this string s, Func<string> action)
+        {
+            return IsNullOrEmptyReturn(action());
+        }
+
+        /// <summary>
         /// If this string ends in "toTrim", this will trim it once off the end
         /// </summary>
         public static string TrimEnd(this string s, string toTrim)

--- a/Opserver.Core/Monitoring/Wmi.cs
+++ b/Opserver.Core/Monitoring/Wmi.cs
@@ -30,9 +30,9 @@ namespace StackExchange.Opserver.Monitoring
                 Timeout = TimeSpan.FromSeconds(30)
             };
             string username = Current.Settings.Dashboard.Providers?.WMI?.Username ??
-                              Current.Settings.Polling.Windows?.AuthUser.IsNullOrEmptyReturn(null),
+                              Current.Settings.Polling.Windows?.AuthUser.IsNullOrEmptyReturn(() => null),
                 password = Current.Settings.Dashboard.Providers?.WMI?.Password ??
-                           Current.Settings.Polling.Windows?.AuthPassword.IsNullOrEmptyReturn(null);
+                           Current.Settings.Polling.Windows?.AuthPassword.IsNullOrEmptyReturn(() => null);
 
             if (username.HasValue() && password.HasValue())
             {


### PR DESCRIPTION
Fixes #86.

PR deals with the case when `objectName` value is missing in `instance` of SQLSettings.json file. So regex comes into place and tries to parse `objectName` value from connection string.

Also added handy string extension method, if you don't mind.