### PR TITLE
Encode instance name (resolves issue with backslashes)

### DIFF
--- a/Opserver/Views/SQL/Dashboard.cshtml
+++ b/Opserver/Views/SQL/Dashboard.cshtml
@@ -14,7 +14,7 @@
     <script>
         $(function() {
             Status.Dashboard.init({ refresh: @(Model.Refresh) });
-            Status.SQL.init({ node: '@(Model.CurrentInstance != null ? Model.CurrentInstance.Name : "")' });
+            Status.SQL.init({ node: '@(Model.CurrentInstance != null ? HttpUtility.JavaScriptStringEncode(Model.CurrentInstance.Name) : "")' });
         });
     </script>
 }


### PR DESCRIPTION
This fixes an issue where some inline JS for SQL Server monitoring wouldn't work correctly when there is a slash in the name.  For example, with this code in the `SQLSettings.json` file:

```json
"instances": [
        { 
            "name": "localhost\\sql2012",
            "connectionString": "Data Source=localhost\\sql2012;Initial Catalog=master;Integrated Security=SSPI;", 
        }
   ]
```

The `sql/instance` page would contain the following *invalid* inline JS (incorrectly escaped backslash in node property):

```javascript
    <script>
        $(function() {
            Status.Dashboard.init({ refresh: 10 });
            Status.SQL.init({ node: 'localhost\sql2012' });
        });
    </script>
```

Clicking the links on this page would just result in a grayed-out page with no additional data.

This PR calls `HttpUtility.JavaScriptStringEncode()` on the instance name which will correctly escape any backslashes in the instance name.  With this fix, the call to `Status.SQL.init()` is correct, and the details links work as expected.