### PR TITLE
Average and Total Duration are in microseconds

### DIFF
--- a/Opserver/Views/SQL/Operations.Top.cshtml
+++ b/Opserver/Views/SQL/Operations.Top.cshtml
@@ -1,4 +1,4 @@
-﻿@using StackExchange.Opserver.Models
+@using StackExchange.Opserver.Models
 @using StackExchange.Opserver.Data.SQL
 @using StackExchange.Opserver.Views.SQL
 @model OperationsTopModel
@@ -8,9 +8,9 @@
     var errorMessage = Model.ErrorMessage;
     if (i == null) { return; }
 }
-@helper ReadableTime(long ms)
+@helper ReadableTime(long microSeconds)
 {
-    @TimeSpan.FromMilliseconds(ms).ToTimeStringMini()
+    @TimeSpan.FromMilliseconds(microSeconds / 1000).ToTimeStringMini()
 }
 @helper SortLink(SQLInstance.TopSorts sort, string title)
 {
@@ -88,7 +88,7 @@ else
             <tr class="plan-row" data-plan-handle="@HttpServerUtility.UrlTokenEncode(o.PlanHandle)" data-offset="@o.StatementStartOffset.ToString()">
                 <td>@o.AvgCPU.ToComma()µs</td>
                 <td>@o.AvgCPUPerMinute.ToComma()µs</td>
-                <td>@ReadableTime(o.TotalCPU/1000)</td>
+                <td>@ReadableTime(o.TotalCPU)</td>
                 <td>@ReadableTime(o.AvgDuration)</td>
                 <td>@ReadableTime(o.TotalDuration)</td>
                 <td>@o.AvgReads.ToComma()</td>


### PR DESCRIPTION
The Average & Total Duration columns are currently reported as if the value is in milliseconds, however they are actually in microseconds.

From https://msdn.microsoft.com/en-us/library/ms189741.aspx
>	
Total amount of CPU time, reported in microseconds (but only accurate to milliseconds), that was consumed by executions of this plan since it was compiled.