### PR TITLE
Support for .net 4.5?

### DIFF
--- a/Opserver/Web.config
+++ b/Opserver/Web.config
@@ -26,7 +26,7 @@
     <authentication mode="Forms">
       <forms name=".ADTkn" loginUrl="~/login" timeout="10080" slidingExpiration="true" protection="All" defaultUrl="~/" cookieless="UseCookies" />
     </authentication>
-    <compilation debug="true" targetFramework="4.6">
+    <compilation debug="true" targetFramework="4.5">
       <assemblies>
         <add assembly="System.Web.Abstractions, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />
         <add assembly="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31BF3856AD364E35" />


### PR DESCRIPTION
The c# build is targeting .net 4.5, however the web.config restricts the framework version to 4.6.  Is there a reason to require .net 4.6?

It would be best to standardise on one or the other, rather than the mix the two.  Either configure both the csproj & web.config to target 4.6, or both to target 4.5.  I've chosen to target 4.5 in this pull request as I don't see anything that specifically requires 4.6.