### PR TITLE
Redis: fixed an issue with double value type conversion

### DIFF
--- a/Opserver.Core/Data/Redis/RedisInfo.Parsing.cs
+++ b/Opserver.Core/Data/Redis/RedisInfo.Parsing.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -93,7 +94,7 @@ namespace StackExchange.Opserver.Data.Redis
                     }
                     else
                     {
-                        prop.SetValue(currentSection, Convert.ChangeType(value, prop.PropertyType));
+                        prop.SetValue(currentSection, Convert.ChangeType(value, prop.PropertyType, CultureInfo.InvariantCulture));
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
For cultures with other decimal separator than dot a FormatException would occur on call to Convert.ChangeType because double could not be parsed to system's expectations.