### PR TITLE
fixed typo in LogPercentUsed calculation

### DIFF
--- a/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGDatabaseReplica.cs
+++ b/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGDatabaseReplica.cs
@@ -64,7 +64,7 @@ namespace StackExchange.Opserver.Data.SQL
             {
                 get
                 {
-                    if (LogKBytesUsed.GetValueOrDefault() <= 0 || LogKBytesUsed.GetValueOrDefault() <= 0) return null;
+                    if (LogKBytesUsed.GetValueOrDefault() <= 0 || LogKBytesTotal.GetValueOrDefault() <= 0) return null;
                     return (double)(LogKBytesUsed / LogKBytesTotal);
                 }
             }


### PR DESCRIPTION
Seems that there's a typo in LogPercentUsed calculation. Same variable is checked twice.