### PR TITLE
Fix 404 for woff2 file.

### DIFF
--- a/Opserver/Web.config
+++ b/Opserver/Web.config
@@ -55,6 +55,10 @@
     </scripting>
   </system.web.extensions>
   <system.webServer>
+    <staticContent>
+      <remove fileExtension=".woff2" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff2" />
+    </staticContent>
     <httpProtocol>
       <customHeaders>
         <remove name="X-Powered-By" />


### PR DESCRIPTION
IIS has no mapping for woff2 file, and that leads to a 404 error.