### PR TITLE
Windows Authentication

### DIFF
--- a/Opserver/Config/SecuritySettings.config.example
+++ b/Opserver/Config/SecuritySettings.config.example
@@ -10,3 +10,15 @@
 Example of global access for everyone:
 <SecuritySettings provider="alladmin" />
 -->
+
+<!-- 
+Example of windows authentication access:
+<SecuritySettings provider="windowsauth" />
+  To use this, also change Web.config:
+    - in the <system.web> section:
+          - remove this block:
+            <authentication mode="Forms">
+              <forms name=".ADTkn" loginUrl="~/login" timeout="10080" slidingExpiration="true" protection="All" defaultUrl="~/" cookieless="UseCookies" />
+            </authentication>
+          - replace it with <authentication mode="Windows" />
+-->

--- a/Opserver/Controllers/LoginController.cs
+++ b/Opserver/Controllers/LoginController.cs
@@ -25,10 +25,12 @@ namespace StackExchange.Opserver.Controllers
             var vd = new LoginModel();
             if (Current.Security.ValidateUser(user, pass))
             {
-                var cookie = FormsAuthentication.GetAuthCookie(user, true);
-                if (Current.IsSecureConnection) cookie.Secure = true;
-                Response.Cookies.Add(cookie);
-
+                if (!(Current.Security is Models.Security.WindowsAuthenticationProvider))
+                {
+                    var cookie = FormsAuthentication.GetAuthCookie(user, true);
+                    if (Current.IsSecureConnection) cookie.Secure = true;
+                    Response.Cookies.Add(cookie);
+                }
                 return Redirect(url.HasValue() ? url : "~/");
             }
             vd.ErrorMessage = "Login failed";

--- a/Opserver/Current.Security.cs
+++ b/Opserver/Current.Security.cs
@@ -18,6 +18,8 @@ namespace StackExchange.Opserver
                     return new ActiveDirectoryProvider(SecuritySettings.Current);
                 case "alladmin":
                     return new EveryonesAnAdminProvider();
+                case "windowsauth":
+                    return new WindowsAuthenticationProvider();
                 //case "allview":
                 default:
                     return new EveryonesReadOnlyProvider();

--- a/Opserver/Models/ExtensionMethods.cs
+++ b/Opserver/Models/ExtensionMethods.cs
@@ -10,6 +10,7 @@ using StackExchange.Opserver.Data;
 using StackExchange.Opserver.Data.Dashboard;
 using StackExchange.Opserver.Data.SQL;
 using StackExchange.Opserver.Helpers;
+using System.Security.Principal;
 
 namespace StackExchange.Opserver.Models
 {
@@ -41,7 +42,11 @@ namespace StackExchange.Opserver.Models
             if (leadingAmp) sb.Insert(0, "&");
             return sb.ToStringRecycle(0, sb.Length - 1).AsHtml();
         }
-    }
+        public static string NameWithoutDomain(this WindowsIdentity identity)
+        {
+            return identity.Name.Substring(identity.Name.IndexOf(@"\") + 1); ;
+        }
+}
 
     public static class VolumeExtensionMethods
     {

--- a/Opserver/Models/Security/WindowsAuthenticationProvider.cs
+++ b/Opserver/Models/Security/WindowsAuthenticationProvider.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.DirectoryServices.AccountManagement;
+using System.Linq;
+using StackExchange.Profiling;
+
+namespace StackExchange.Opserver.Models.Security
+{
+    /// <summary>
+    /// To use - set Authentication to Windows in web.config
+    /// </summary>
+    public class WindowsAuthenticationProvider : SecurityProvider
+    {
+        public override bool ValidateUser(string userName, string password) { return true; }
+
+        public override bool InGroups(string groupNames, string accountName)
+        {
+            var groups = groupNames.Split(StringSplits.Comma_SemiColon);
+            if (groupNames.Length == 0) return false;
+
+            return groups.Any(g =>
+            {
+                var members = GetGroupMembers(g);
+                return members != null && members.Contains(accountName, StringComparer.InvariantCultureIgnoreCase);
+            });
+        }
+        public override List<string> GetGroupMembers(string groupName)
+        {
+            return Current.LocalCache.GetSet<List<string>>("ADMembers-" + groupName,
+                (old, ctx) =>
+                {
+                    using (MiniProfiler.Current.Step("Getting members for " + groupName))
+                    {
+                        //var pc = new PrincipalContext(ContextType.Domain, null);
+                        var pc = new PrincipalContext(ContextType.Domain, "business-post.com");
+                        using (var gp = GroupPrincipal.FindByIdentity(pc, groupName))
+                        {
+                            var group = gp?.GetMembers(true).ToList().Select(mp => mp.SamAccountName).ToList() ?? new List<string>();
+                            return group ?? old ?? new List<string>();
+                        }
+
+                    }
+                }, 5 * 60, 60 * 60 * 24);
+        }      
+    }
+}

--- a/Opserver/Models/User.cs
+++ b/Opserver/Models/User.cs
@@ -15,16 +15,33 @@ namespace StackExchange.Opserver.Models
         public User(IIdentity identity)
         {
             Identity = identity;
-            var i = identity as FormsIdentity;
-            if (i == null)
+            if (Current.Security is StackExchange.Opserver.Models.Security.WindowsAuthenticationProvider)
             {
-                IsAnonymous = true;
-                return;
+                var i = identity as WindowsIdentity;
+                if (i == null)
+                {
+                    IsAnonymous = true;
+                    return;
+                }
+
+                IsAnonymous = !i.IsAuthenticated;
+                if (i.IsAuthenticated)
+                    AccountName = i.NameWithoutDomain();
+            }
+            else
+            {
+                var i = identity as FormsIdentity;
+                if (i == null)
+                {
+                    IsAnonymous = true;
+                    return;
+                }
+
+                IsAnonymous = !i.IsAuthenticated;
+                if (i.IsAuthenticated)
+                    AccountName = i.Name;
             }
 
-            IsAnonymous = !i.IsAuthenticated;
-            if (i.IsAuthenticated)
-                AccountName = i.Name;
         }
 
         public bool IsInRole(string role)

--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -164,6 +164,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Models\Security\WindowsAuthenticationProvider.cs" />
     <Compile Include="Views\Dashboard\Node.Graph.Model.cs">
       <DependentUpon>Node.Graph.cshtml</DependentUpon>
     </Compile>

--- a/Opserver/Web.config
+++ b/Opserver/Web.config
@@ -27,6 +27,15 @@
       </system.Web>
   -->
   <system.web>
+    <!-- 
+      To use windows authentication set <SecuritySettings provider="windowsauth" /> in SecuritySettings.config
+      To use any other authentication:
+          - remove from below this block:
+            <authentication mode="Forms">
+              <forms name=".ADTkn" loginUrl="~/login" timeout="10080" slidingExpiration="true" protection="All" defaultUrl="~/" cookieless="UseCookies" />
+            </authentication>
+          - replace it with <authentication mode="Windows" />
+    -->
     <authentication mode="Forms">
       <forms name=".ADTkn" loginUrl="~/login" timeout="10080" slidingExpiration="true" protection="All" defaultUrl="~/" cookieless="UseCookies" />
     </authentication>


### PR DESCRIPTION
Allows windows authentication directly through the browser to IIS, so no username and password
required.
Note that normally IE is used for this, but opserver does not display properly in IE11. You can configure mozilla or chrome to turn on ntlm for specified sites.