### PR TITLE
Fix for "Sequence contains no elements" in graph/interface

### DIFF
--- a/Opserver/Controllers/GraphController.Spark.cs
+++ b/Opserver/Controllers/GraphController.Spark.cs
@@ -66,7 +66,7 @@ namespace StackExchange.Opserver.Controllers
             Func<DoubleGraphPoint, double> getter = p => p.Value.GetValueOrDefault(0);
             if (direction == "out") getter = p => p.BottomValue.GetValueOrDefault(0);
 
-            return SparkSVG(points, Convert.ToInt64(points.Max(getter)), getter);
+            return SparkSVG(points, Convert.ToInt64(points.DefaultIfEmpty(new DoubleGraphPoint()).Max(getter)), getter);
         }
 
         [OutputCache(Duration = 120, VaryByParam = "node", VaryByContentEncoding = "gzip;deflate")]


### PR DESCRIPTION
The code (`graph/interface/in/spark`) was crashing because the `points` collection was empty and we
were calling `Max()` on it.
![opserver-grpah-exception](https://cloud.githubusercontent.com/assets/144469/13832615/438eedae-ebb4-11e5-83a6-bcbd2730dbed.PNG)
.
**Fix :** Added `DefaultIfEmpty `method call to the
collection which will add a dummy item to the collection if it is empty.