### PR TITLE
Adding Config as a hidden segment in IIS

### DIFF
--- a/Opserver/Web.config
+++ b/Opserver/Web.config
@@ -69,6 +69,13 @@
     <modules runAllManagedModulesForAllRequests="true">
       <add name="ErrorLog" type="StackExchange.Exceptional.ExceptionalModule, StackExchange.Exceptional" />
     </modules>
+        <security>
+            <requestFiltering>
+                <hiddenSegments>
+                    <add segment="Config" />
+                </hiddenSegments>
+            </requestFiltering>
+        </security>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
Config files may contain some sensitive information, so blocks those files from being accessible through a browser.