### PR TITLE
Restore history tab to database view

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -338,14 +338,15 @@ Select db.database_id DatabaseId,
         {
             public DateTime RestoreDate { get; internal set; }
             public string  UserName { get; internal set; }
-            public string BackupUsed { get; internal set; }
+            public string BackupMedia { get; internal set; }
+            public DateTime BackupDate { get; internal set; }
 
             public Version MinVersion =>  SQLServerVersions.SQL2008.SP1;
             public string GetFetchSQL(Version v)
             {
                 return @"SELECT r.restore_date RestoreDate, 
                                             r.user_name UserName, 
-                                            bmf.physical_device_name BackupUsed
+                                            bmf.physical_device_name BackupMedia,bs.backup_finish_date BackupDate
                                             FROM msdb.dbo.[restorehistory] r 
                                             JOIN  [msdb].[dbo].[backupset] bs ON bs.backup_set_id=r.backup_set_id
                                             JOIN  [msdb].[dbo].[backupmediafamily] bmf on bmf.media_set_id = bs.media_set_id

--- a/Opserver/Controllers/SQLController.cs
+++ b/Opserver/Controllers/SQLController.cs
@@ -224,7 +224,7 @@ namespace StackExchange.Opserver.Controllers
 
                 case "restorehistory":
                     vd.View = DatabasesModel.Views.RestoreHistory;
-                    return View("Databases.Modal.Backups", vd);
+                    return View("Databases.Modal.RestoreHistory", vd);
 
                 case "storage":
                     vd.View = DatabasesModel.Views.Storage;

--- a/Opserver/Controllers/SQLController.cs
+++ b/Opserver/Controllers/SQLController.cs
@@ -221,6 +221,11 @@ namespace StackExchange.Opserver.Controllers
                 case "backups":
                     vd.View = DatabasesModel.Views.Backups;
                     return View("Databases.Modal.Backups", vd);
+
+                case "restorehistory":
+                    vd.View = DatabasesModel.Views.RestoreHistory;
+                    return View("Databases.Modal.Backups", vd);
+
                 case "storage":
                     vd.View = DatabasesModel.Views.Storage;
                     return View("Databases.Modal.Storage", vd);

--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -462,6 +462,9 @@
     <Content Include="Views\SQL\Databases.Modal.Columns.cshtml">
       <DependentUpon>Databases.Modal.cshtml</DependentUpon>
     </Content>
+    <Content Include="Views\SQL\Databases.Modal.RestoreHistory.cshtml">
+      <DependentUpon>Databases.Modal.cshtml</DependentUpon>
+    </Content>
     <Content Include="Views\SQL\Databases.Modal.Storage.cshtml">
       <DependentUpon>Databases.Modal.cshtml</DependentUpon>
     </Content>

--- a/Opserver/Views/SQL/Databases.Modal.RestoreHistory.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.RestoreHistory.cshtml
@@ -18,7 +18,8 @@ else {
             <tr>
                 <th>Restore date</th>
                 <th>User</th>
-                <th>Backup used</th>
+                <th>Backup media used</th>
+                <th>Backup created date</th>
             </tr>
         </thead>
         <tbody>
@@ -28,7 +29,8 @@ else {
 
                     <td>@(b.RestoreDate.ToRelativeTimeSpanMini())</td>
                     <td>@b.UserName</td>
-                    <td title="@b.BackupUsed">@b.BackupUsed.TruncateWithEllipsis(75)</td>
+                    <td title="@b.BackupMedia">@b.BackupMedia.TruncateWithEllipsis(75)</td>
+                    <td title="@b.BackupDate.ToString()">@(b.BackupDate.ToRelativeTimeSpanMini())</td>
                 </tr>
             }
         </tbody>

--- a/Opserver/Views/SQL/Databases.Modal.RestoreHistory.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.RestoreHistory.cshtml
@@ -1,0 +1,57 @@
+﻿@using StackExchange.Opserver.Views.SQL
+@model DatabasesModel
+@{
+    Layout = "Databases.Modal.cshtml";
+    var s = Model.Instance;
+    var restoreList = s.GetRestoreHistory(Model.Database);
+}
+@if (restoreList.Data == null || !restoreList.LastPollSuccessful)
+{
+    <div class="alert alert-warning">
+        <h5>There was an error fetching restore info from @s.Name for @Model.Database</h5>
+        <p class="error-stack">@restoreList.ErrorMessage</p>
+    </div>
+}
+else {
+    <table class="table table-striped table-hover text-nowrap table-super-condensed table-responsive js-database-restore-log">
+        <thead>
+            <tr>
+                <th>Restore date</th>
+                <th>User</th>
+                <th>Backup used</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var b in restoreList.Data.OrderByDescending(b => b.RestoreDate))
+            {
+                <tr>
+
+                    <td>@(b.RestoreDate.ToRelativeTimeSpanMini())</td>
+                    <td>@b.UserName</td>
+                    <td title="@b.BackupUsed">@b.BackupUsed.TruncateWithEllipsis(75)</td>
+                </tr>
+            }
+        </tbody>
+        <tfoot>
+            @if (!restoreList.Data.Any())
+            {
+                <tr>
+                    <td colspan="6">
+                        <div class="none-active">There aren't any info about restoration history.</div>
+                    </td>
+                </tr>
+            }
+        </tfoot>
+    </table>
+    <script>
+        $(function () {
+            $('.js-database-restore-log').tablesorter({
+                headers: {
+                    1: { sorter: 'dataVal', sortInitialOrder: 'desc' },
+                    2: { sorter: 'dataVal', sortInitialOrder: 'desc' },
+                    3: { sorter: 'dataVal', sortInitialOrder: 'desc' }
+                }
+            });
+        });
+    </script>
+}

--- a/Opserver/Views/SQL/Databases.Modal.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.cshtml
@@ -21,6 +21,7 @@
     <div class="navbar-left col-md-2">
         @RenderLink(DatabasesModel.Views.Tables, "Tables")
         @RenderLink(DatabasesModel.Views.Backups, "Backups")
+        @RenderLink(DatabasesModel.Views.RestoreHistory, "Restore History")
         @RenderLink(DatabasesModel.Views.Views, "Views")
         @RenderLink(DatabasesModel.Views.Storage, "Storage")
         @RenderLink(DatabasesModel.Views.MissingIndexes, "Missing Indexes", true)

--- a/Opserver/Views/SQL/Databases.Model.cs
+++ b/Opserver/Views/SQL/Databases.Model.cs
@@ -20,7 +20,8 @@ namespace StackExchange.Opserver.Views.SQL
             MissingIndexes,
             UnusedIndexes,
             Storage,
-            Other
+            Other,
+            RestoreHistory
         }
 
         public static string GetDatabaseClass(SQLInstance.Database db)


### PR DESCRIPTION
Adding "Restore history" tab to database view. This allows us to see the history of restorations happened to a database. 

![opserver-sql-restore-history](https://cloud.githubusercontent.com/assets/144469/14292053/51c53d76-fb34-11e5-8855-b7677da6b152.png)
