### PR TITLE
Remove N1 format

### DIFF
--- a/Opserver/Controllers/GraphController.Spark.cs
+++ b/Opserver/Controllers/GraphController.Spark.cs
@@ -117,14 +117,14 @@ namespace StackExchange.Opserver.Controllers
                 if (first && pos > 0)
                 {
                     // TODO: Indicate a missing, ungraphed time portion?
-                    sb.Append((pos - 1).ToString("n1", CultureInfo.InvariantCulture))
+                    sb.Append((pos - 1).ToString("f1", CultureInfo.InvariantCulture))
                       .Append(" ")
                       .Append(height)
                       .Append(" ");
                     first = false;
                 }
-                sb.Append(pos.ToString("n1", CultureInfo.InvariantCulture)).Append(" ")
-                  .Append((height - getVal(p) / divisor).ToString("n1", CultureInfo.InvariantCulture)).Append(" ");
+                sb.Append(pos.ToString("f1", CultureInfo.InvariantCulture)).Append(" ")
+                  .Append((height - getVal(p) / divisor).ToString("f1", CultureInfo.InvariantCulture)).Append(" ");
             }
             sb.Append(width)
               .Append(" ")


### PR DESCRIPTION
For integer greater than 999, the n1 format add thousand separator. I removed the "n1" parameter but I'm not sure if this is the exact fix. Maybe "f1" would be better.
