### PR TITLE
Adding missing indexes to sql database view

### DIFF
--- a/Opserver.Core/ExtensionMethods.cs
+++ b/Opserver.Core/ExtensionMethods.cs
@@ -84,6 +84,7 @@ namespace StackExchange.Opserver
                     ? item.Remove(item.Length - 1) + "ies"
                     : item.EndsWith("s")
                         ? item.Remove(item.Length - 1) + "es"
+                        : item.EndsWith("ex")? item+"es"
                         : item + "s");
         }
 

--- a/Opserver/Controllers/SQLController.cs
+++ b/Opserver/Controllers/SQLController.cs
@@ -233,6 +233,9 @@ namespace StackExchange.Opserver.Controllers
                 case "views":
                     vd.View = DatabasesModel.Views.Views;
                     return View("Databases.Modal.Views", vd);
+                case "missingindexes":
+                    vd.View = DatabasesModel.Views.MissingIndexes;
+                    return View("Databases.Modal.MissingIndexes", vd);
             }
             return View("Databases.Modal.Tables", vd);
         }

--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -462,6 +462,9 @@
     <Content Include="Views\SQL\Databases.Modal.Columns.cshtml">
       <DependentUpon>Databases.Modal.cshtml</DependentUpon>
     </Content>
+    <Content Include="Views\SQL\Databases.Modal.MissingIndexes.cshtml">
+      <DependentUpon>Databases.Modal.cshtml</DependentUpon>
+    </Content>
     <Content Include="Views\SQL\Databases.Modal.Restores.cshtml">
       <DependentUpon>Databases.Modal.cshtml</DependentUpon>
     </Content>

--- a/Opserver/Views/SQL/Databases.Modal.MissingIndexes.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.MissingIndexes.cshtml
@@ -1,0 +1,54 @@
+﻿@using System.Globalization
+@using StackExchange.Opserver.Views.SQL
+@model DatabasesModel
+@{
+    Layout = "Databases.Modal.cshtml";
+    var s = Model.Instance;
+    var missingIndexList = s.GetMissingIndexes(Model.Database);
+}
+@if (missingIndexList.Data == null || !missingIndexList.LastPollSuccessful)
+{
+    <div class="alert alert-warning">
+        <h5>There was an error fetching missing indexes info from @s.Name for @Model.Database</h5>
+        <p class="error-stack">@missingIndexList.ErrorMessage</p>
+    </div>
+}
+else {
+    <table class="table table-striped table-hover text-nowrap table-super-condensed table-responsive js-database-missing-index-log">
+        <thead>
+            <tr>
+                <th>Table</th>
+                <th>Column Name</th>
+                <th>Column Usage</th>
+                <th>Avg User Impact</th>
+                <th>Avg Total User Cost</th>
+                <th>User Scans</th>
+                <th>User Seeks</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var t in missingIndexList.Data.OrderByDescending(b => b.AnticipatedImprovement))
+            {
+                <tr title="Anticipated improvement @t.AnticipatedImprovement">
+                    <td><span class="text-muted">@(t.SchemaName).</span><span>@t.TableName</span></td>
+                    <td>@t.ColumnName</td>
+                    <td>@t.ColumnUsage</td>
+                    <td>@t.AverageUserImpact</td>
+                    <td title="@t.AverageTotalUserCost">@t.AverageTotalUserCost.ToString("##.####")</td>
+                    <td>@t.UserScans</td>
+                    <td>@t.UserSeeks</td>
+                </tr>
+            }
+        </tbody>
+        <tfoot>
+            <tr class="total-row">
+                <td colspan="7"><b>Total</b> <span class="note">(@missingIndexList.Data.Count().Pluralize("missing index"))</span></td>
+            </tr>
+        </tfoot>
+    </table>
+    <script>
+        $(function () {
+            $('.js-database-missing-index-log').tablesorter();
+        });
+    </script>
+}

--- a/Opserver/Views/SQL/Databases.Modal.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.cshtml
@@ -24,7 +24,7 @@
         @RenderLink(DatabasesModel.Views.Restores, "Restores")
         @RenderLink(DatabasesModel.Views.Views, "Views")
         @RenderLink(DatabasesModel.Views.Storage, "Storage")
-        @RenderLink(DatabasesModel.Views.MissingIndexes, "Missing Indexes", true)
+        @RenderLink(DatabasesModel.Views.MissingIndexes, "Missing Indexes")
         @RenderLink(DatabasesModel.Views.UnusedIndexes, "Unused Indexes", true)
         @RenderLink(DatabasesModel.Views.BlitzIndex, "Blitz Index", true)
     </div>


### PR DESCRIPTION
Adding missing indexes to sql database view.

No news about this since Mar 6th :( . So here is another revised version

I also updated the extension method `Pluralize` to support words ends with 'ex' such as vertex, cleenex,multiplex and index.

Thanks 