### PR TITLE
Fix ObjectName passed from SQL Settings

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.cs
@@ -37,7 +37,14 @@ namespace StackExchange.Opserver.Data.SQL
             // Grab the instance name for performance counters and such
             var csb = new SqlConnectionStringBuilder(ConnectionString);
             var parts = csb.DataSource?.Split(StringSplits.BackSlash);
-            ObjectName = parts?.Length == 2 ? "MSSQL$" + parts[1].ToUpper() : "SQLServer";
+            if(!String.IsNullOrEmpty(Settings.ObjectName))
+            {
+                ObjectName = Settings.ObjectName;
+            }
+            else
+            {
+                ObjectName = parts?.Length == 2 ? "MSSQL$" + parts[1].ToUpper() : "SQLServer";
+            }
         }
 
         public static SQLInstance Get(string name)


### PR DESCRIPTION
When specifying the objectName parameter in SqlSettings.json, the value would not be used in the SQL Instance.

This would cause the performance metrics for the SQL Instance to not be shown.