### PR TITLE
Visual Representation of values in SQL Top Queries view

### DIFF
--- a/Opserver/Views/SQL/Operations.Top.cshtml
+++ b/Opserver/Views/SQL/Operations.Top.cshtml
@@ -32,6 +32,13 @@
         <input type="radio" name="LastRunSeconds" value="@secs.ToString()" checked="@isChecked" /> @label
     </label>
 }
+@helper VisualIndicator(decimal value, decimal maximum, string title = "")
+{
+    <div class="progress vertical" title="@title" >
+        <div class="progress-bar" style="height: @((100 * value / maximum).ToString("0.00"))%"></div>
+    </div>
+}
+
 @if (errorMessage.HasValue())
 {
     <h5 class="page-header">
@@ -56,6 +63,7 @@ else
     <table class="table table-striped table-hover text-nowrap table-super-condensed table-responsive table-row-actions">
         <thead>
             <tr class="sort-row sort-category">
+                <th>Visual</th>
                 <th colspan="3">CPU</th>
                 <th colspan="2">Time</th>
                 <th colspan="2">Reads</th>
@@ -64,6 +72,8 @@ else
                 <th colspan="2">Query Info</th>
             </tr>
             <tr class="sort-row">
+                <th></th>
+
                 @SortLink(SQLInstance.TopSorts.AvgCPU, "Avg")
                 @SortLink(SQLInstance.TopSorts.AvgCPUPerMinute, "Avg/min")
                 @SortLink(SQLInstance.TopSorts.TotalCPU, "Total")
@@ -82,23 +92,6 @@ else
             </tr>
         </thead>
         <tbody>
-        @foreach (var o in topOps)
-        {
-            <tr class="plan-row" data-plan-handle="@HttpServerUtility.UrlTokenEncode(o.PlanHandle)" data-offset="@o.StatementStartOffset.ToString()">
-                <td>@o.AvgCPU.ToComma()µs</td>
-                <td>@o.AvgCPUPerMinute.ToComma()µs</td>
-                <td>@ReadableTime(o.TotalCPU)</td>
-                <td>@ReadableTime(o.AvgDuration)</td>
-                <td>@ReadableTime(o.TotalDuration)</td>
-                <td>@o.AvgReads.ToComma()</td>
-                <td>@o.TotalReads.ToComma()</td>
-                <td>@o.ExecutionCount.ToComma()</td>
-                <td>@o.ExecutionsPerMinute.ToString("0.00")</td>
-                <td>@o.LastExecutionTime.ToRelativeTimeSpan()</td>
-                <td>@o.CompiledOnDatabase</td>
-                <td class="query-col" title="@o.QueryText">@o.QueryText.TruncateWithEllipsis(80)</td>
-            </tr>
-        }
         @if (!topOps.Any())
         {
             <tr>
@@ -106,6 +99,47 @@ else
                     <div class="no-content">There are no operations in the plan cache on this server.</div>
                 </td>
             </tr>
+        }
+        else
+        {
+            var maxAvgCPU = topOps.Max(x => x.AvgCPU);
+            var maxAvgCPUPerMinute = topOps.Max(x => x.AvgCPUPerMinute);
+            var maxTotalCPU = topOps.Max(x => x.TotalCPU);
+            var maxAvgDuration = topOps.Max(x => x.AvgDuration);
+            var maxTotalDuration = topOps.Max(x => x.TotalDuration);
+            var maxAvgReads = topOps.Max(x => x.AvgReads);
+            var maxTotalReads = topOps.Max(x => x.TotalReads);
+            var maxExecutionCount = topOps.Max(x => x.ExecutionCount);
+            var maxExecutionsPerMinute = topOps.Max(x => x.ExecutionsPerMinute);
+
+            foreach (var o in topOps)
+            {
+                <tr class="plan-row" data-plan-handle="@HttpServerUtility.UrlTokenEncode(o.PlanHandle)" data-offset="@o.StatementStartOffset.ToString()">
+                    <td>
+                        @VisualIndicator(o.AvgCPU, maxAvgCPU, "Avg CPU")
+                        @VisualIndicator(o.AvgDuration, maxAvgDuration, "Avg Time")
+                        @VisualIndicator(o.AvgReads, maxAvgReads, "Avg Reads")
+                        @VisualIndicator(o.TotalCPU, maxTotalCPU, "Total CPU")
+                        @VisualIndicator(o.TotalDuration, maxTotalDuration, "Total Time")
+                        @VisualIndicator(o.TotalReads, maxTotalReads, "Total Reads")
+                        @VisualIndicator(o.ExecutionCount, maxExecutionCount, "Total Executions")
+                        @VisualIndicator(o.AvgCPUPerMinute, maxAvgCPUPerMinute, "Avg CPU /minute")
+                        @VisualIndicator(o.ExecutionsPerMinute, maxExecutionsPerMinute, "Executions /minute")
+                    </td>
+                    <td>@o.AvgCPU.ToComma()µs</td>
+                    <td>@o.AvgCPUPerMinute.ToComma()µs</td>
+                    <td>@ReadableTime(o.TotalCPU)</td>
+                    <td>@ReadableTime(o.AvgDuration)</td>
+                    <td>@ReadableTime(o.TotalDuration)</td>
+                    <td>@o.AvgReads.ToComma()</td>
+                    <td>@o.TotalReads.ToComma()</td>
+                    <td>@o.ExecutionCount.ToComma()</td>
+                    <td>@o.ExecutionsPerMinute.ToString("0.00")</td>
+                    <td>@o.LastExecutionTime.ToRelativeTimeSpan()</td>
+                    <td>@o.CompiledOnDatabase</td>
+                    <td class="query-col" title="@o.QueryText">@o.QueryText.TruncateWithEllipsis(80)</td>
+                </tr>
+            }
         }
         </tbody>
     </table>


### PR DESCRIPTION
In the Top SQL Queries view I find that most of the values end up being too large to comprehend.  What I find is more often of interest is not so the actual numbers, but their relative value to others .  For this I am trying to come up with a way to visually represent this.

What I have come up with so far is putting a small bar graph beside each query, where bar shows the size of the query stats against the maximum value.  

![image](https://cloud.githubusercontent.com/assets/289860/17194280/0f8e8c2c-544f-11e6-962d-d7def2b7abc8.png)

I like how this is very concise and unobtrusive, although I'm not sure if it's a bit cryptic - it makes perfect sense to me having written it, but is that true of other users?  I also found that (for my workload at least), the columns were better ordered by "Avg -> Total -> Per Min" rather than "CPU -> Time -> Reads -> Executions" which makes it easier to read, but makes it more cryptic to understand as the bar order doesn't match the column order.  

Any feedback / comment on this idea, or alternative ways of visualising the numbers?

For reference, below are a few other approaches I tried (but rejected)

Adding a bar under each (like the Memory usage on the dashboards) - this I felt just made the page too cluttered, and I found the bars too small to read.
![image](https://cloud.githubusercontent.com/assets/289860/17193973/5fc14592-544d-11e6-9f7f-d725638807c6.png)

Vertical bar beside each value - the vertical bars are a bit fatter so easeir to read, but still left the page feeling cluttered.
![image](https://cloud.githubusercontent.com/assets/289860/17194044/de2bd820-544d-11e6-9715-d3e5f1ccbc12.png)
