### PR TITLE
Fix for broken search dropdown in Active operations filter

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.ActiveOperations.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.ActiveOperations.cs
@@ -314,11 +314,11 @@ Exec sp_WhoIsActive
 
             public enum FilterFields
             {
-                Session = 0,
-                Program = 1,
-                Database = 2,
-                Login = 3,
-                Host = 4
+                [Description("Session")] Session = 0,
+                [Description("Program")] Program = 1,
+                [Description("Database")] Database = 2,
+                [Description("Login")] Login = 3,
+                [Description("Host")] Host = 4
             }
         }
     }

--- a/Opserver/Views/SQL/Operations.Active.cshtml
+++ b/Opserver/Views/SQL/Operations.Active.cshtml
@@ -38,7 +38,7 @@ else
     {
         var data = activeOps.SafeData(true);
         <h5 class="page-header">
-            Current active queries on @i.Name:
+            @data.Count Active queries currently on @i.Name:  
             <span class="pull-right">
                 <a href="#/sql/active/filters" class="hover-pulsate@(Model.ActiveSearchOptions.IsNonDefault ? " text-warning" : "")"><span class="glyphicon glyphicon-filter"></span></a>
                 <a href="#" class="js-reload-link">Reload</a>


### PR DESCRIPTION

The code in `Operations.Active.Fitlers.cshtml` uses `GetDescription`
extension method to return the description attribute value of the enum.
It was missing and hence rendering the dropdown options with empty text.
Fixed that. Also added the  current active query count to the Active
queries page.

![active-filter-empty-dropdown](https://cloud.githubusercontent.com/assets/144469/17640840/6f77d442-60d7-11e6-85f9-4843bfe7bd46.png)
