### PR TITLE
The leading slash breaks AJAX

### DIFF
--- a/Opserver/Views/PagerDuty/PagerDuty.cshtml
+++ b/Opserver/Views/PagerDuty/PagerDuty.cshtml
@@ -34,10 +34,10 @@
         $(function() {
             Status.loaders.register({
                 '#/pagerduty/incident/': function (val) {
-                    Status.popup('/pagerduty/incident/' + val);
+                    Status.popup('pagerduty/incident/' + val);
                 },
-                '#/pagerduty/escalation/': function(val) {
-                    Status.popup('/pagerduty/escalation/' + val);
+                '#/pagerduty/escalation/': function (val) {
+                    Status.popup('pagerduty/escalation/' + val);
                 }
             });
             $(".js-incident-action").on('click', function(e) {


### PR DESCRIPTION
The PagerDuty popups where broken due to leading slash breaking ajax and causing it to try and connect to http://pagerduty/<path>