### PR TITLE
Adding null check. 

### DIFF
--- a/Opserver/Controllers/SQLController.cs
+++ b/Opserver/Controllers/SQLController.cs
@@ -187,9 +187,11 @@ namespace StackExchange.Opserver.Controllers
             {
                 View = SQLViews.Connections,
                 CurrentInstance = i,
-                Cache = i.Connections,
-                Connections = await i.Connections.GetData()
+                Cache = i?.Connections
             };
+            var d = i?.Connections?.GetData();
+            if (d != null) vd.Connections = await d;
+
             return View(vd);
         }
 


### PR DESCRIPTION
Fixing a null reference exception in `Sql/Connections`.

**Steps to replicate**
1. Go to Sql Servers page(`/sql/servers`).
2. Click on `connections` tab (_without selecting any sql server instance_)
3. You will see the null reference error.

Added a null check before assigning the `Cache` property value. Now it will show the instance selection markup from the layout.

