### PR TITLE
added  <meta http-equiv="X-UA-Compatible" content="IE=edge" />

### DIFF
--- a/Opserver/Views/Shared/Master.cshtml
+++ b/Opserver/Views/Shared/Master.cshtml
@@ -9,6 +9,7 @@
 <head>
     <title>@Html.Raw((string)ViewData[ViewDataKeys.PageTitle])</title>
     <meta name="viewport" content="width=device-width">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="google" value="notranslate" />
     <link rel="stylesheet" href="@Url.CacheBreaker("~/Content/themes/" + Theme.Current + "/styles.min.css")">
     <link href="@Url.CacheBreaker("~/Content/img/apple-touch-icon.png")" rel="apple-touch-icon"/>


### PR DESCRIPTION
without explicit X-UA-Compatible my IE randomly dropped to "IE7 mode" (I could not figure out why), d3.js does not in IE7 mode.