### PR TITLE
Null-ref bugfix for VMs that have their hosts filtered through the exclusion list.

### DIFF
--- a/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
@@ -146,7 +146,7 @@ Order By NodeID", commandTimeout: QueryTimeoutMs).ConfigureAwait(false);
                     var exclude = Current.Settings.Dashboard.ExcludePatternRegex;
                     if (exclude != null)
                     {
-                        nodes = nodes.Where(n => !exclude.IsMatch(n.Name)).ToList();
+                        nodes = nodes.Where(n => !exclude.IsMatch(n.Name) || (n.IsVMHost && nodes.Any(x => x.IsVM && x.VMHostID == n.Id))).ToList();
                     }
 
                     foreach (var n in nodes)

--- a/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
@@ -143,18 +143,10 @@ Order By NodeID", commandTimeout: QueryTimeoutMs).ConfigureAwait(false);
                         i.IPs = ips.Where(ip => i.Id == ip.InterfaceID && ip.IPNet != null).Select(ip => ip.IPNet).ToList();
                     }
 
-                    var include = Current.Settings.Dashboard.IncludePatternRegex;
-                    if (include != null)
-                    {
-                        var candidateNodes = nodes.Where(n => include.IsMatch(n.Name)).ToList();
-                        nodes = nodes.Where(n => include.IsMatch(n.Name) || (n.IsVMHost && candidateNodes.Any(x => x.IsVM && x.VMHostID == n.Id))).ToList();
-                    }
-
                     var exclude = Current.Settings.Dashboard.ExcludePatternRegex;
                     if (exclude != null)
                     {
-                        var candidateNodes = nodes.Where(n => !include.IsMatch(n.Name)).ToList();
-                        nodes = nodes.Where(n => !exclude.IsMatch(n.Name) || (n.IsVMHost && candidateNodes.Any(x => x.IsVM && x.VMHostID == n.Id))).ToList();
+                        nodes = nodes.Where(n => !exclude.IsMatch(n.Name) || (n.IsVMHost && nodes.Any(x => x.IsVM && x.VMHostID == n.Id))).ToList();
                     }
 
                     foreach (var n in nodes)

--- a/Opserver.Core/Settings/DashboardSettings.cs
+++ b/Opserver.Core/Settings/DashboardSettings.cs
@@ -22,14 +22,6 @@ namespace StackExchange.Opserver
         #region Direct Properties
 
         /// <summary>
-        /// The Pattern to match on server names to display on the dashboard. This is evaluated before the <see cref="ExcludePattern"/>.
-        /// </summary>
-        public string IncludePattern { get; set; }
-
-        private Regex _includePatternRegEx;
-        public Regex IncludePatternRegex => _includePatternRegEx ?? (IncludePattern.HasValue() ? _includePatternRegEx = new Regex(IncludePattern, RegexOptions.IgnoreCase | RegexOptions.Singleline) : null);
-
-        /// <summary>
         /// The Pattern to match on server names for hiding from the dashboard
         /// </summary>
         public string ExcludePattern { get; set; }

--- a/Opserver.Core/Settings/DashboardSettings.cs
+++ b/Opserver.Core/Settings/DashboardSettings.cs
@@ -22,6 +22,14 @@ namespace StackExchange.Opserver
         #region Direct Properties
 
         /// <summary>
+        /// The Pattern to match on server names to display on the dashboard. This is evaluated before the <see cref="ExcludePattern"/>.
+        /// </summary>
+        public string IncludePattern { get; set; }
+
+        private Regex _includePatternRegEx;
+        public Regex IncludePatternRegex => _includePatternRegEx ?? (IncludePattern.HasValue() ? _includePatternRegEx = new Regex(IncludePattern, RegexOptions.IgnoreCase | RegexOptions.Singleline) : null);
+
+        /// <summary>
         /// The Pattern to match on server names for hiding from the dashboard
         /// </summary>
         public string ExcludePattern { get; set; }


### PR DESCRIPTION
I added an optional inclusion filter into the Dashboard configuration settings, which is evaluated before the exclusion filter, which is handy for cases where Orion is for example monitoring a bunch of VM hosts that might have hundreds of VMs running instead of having to create a humongous or illegible exclusion filter.

Also, made sure that the appropriate VM Hosts are never excluded if their VMs are included in the final node list. Possibly it might be a better solution to just display a message for nodes where the IsVM property is true but the VMHost is null (if it was excluded) but that's debatable.