### PR TITLE
Fixing the View All link href value on Exceptions page

### DIFF
--- a/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Navigation.cshtml
@@ -1,10 +1,11 @@
 ﻿@model StackExchange.Opserver.Views.Exceptions.ExceptionsModel
+@using StackExchange.Opserver.Controllers
 @{
     Layout = null;
 }
 @if (Model.Groups.Count > 1)
 {
-    <a href="/exceptions" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
+    <a href="@Url.Action(nameof(ExceptionsController.Exceptions))" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
 }
 @foreach (var g in Model.Groups)
 {


### PR DESCRIPTION
Fixing the "View All" link href  attribute value on Exceptions page so that it will
work when deployed under virtual directory. Related to fixes from #118 