### PR TITLE
Fixing the call to RenderLink method call for missing indexes link

### DIFF
--- a/Opserver/Views/SQL/Databases.Modal.cshtml
+++ b/Opserver/Views/SQL/Databases.Modal.cshtml
@@ -26,7 +26,7 @@
         @RenderLink(DatabasesModel.Views.Backups, "Backups", "archive")
         @RenderLink(DatabasesModel.Views.Restores, "Restores", "history")
         @RenderLink(DatabasesModel.Views.Storage, "Storage", "hdd-o")
-        @RenderLink(DatabasesModel.Views.MissingIndexes, "Missing Indexes", "question-circle-o", Model.Instance.Supports<SQLInstance.MissingIndex>())
+        @RenderLink(DatabasesModel.Views.MissingIndexes, "Missing Indexes", "question-circle-o", !Model.Instance.Supports<SQLInstance.MissingIndex>())
         @RenderLink(DatabasesModel.Views.UnusedIndexes, "Unused Indexes", "square-o", true)
         @RenderLink(DatabasesModel.Views.BlitzIndex, "Blitz Index", "bolt", true)
     </div>


### PR DESCRIPTION
The third parameter of `RenderLink` method is to make the link disabled. So even if the expression `Model.Instance.Supports<SQLInstance.MissingIndex>()` return `true`, we should convert it to `false`. disabled=true =>enabled.