### PR TITLE
Reduce permissions required for WMI

### DIFF
--- a/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
+++ b/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
@@ -483,16 +483,9 @@ SELECT Caption,
 
             #region private helpers
 
-            private async Task<bool> GetIsVMHost()
-            {
-                const string query = "SELECT Name FROM Win32_OptionalFeature WHERE (Name = 'Microsoft-Hyper-V' OR Name = 'Microsoft-Hyper-V-Hypervisor') AND InstallState = 1";
+            private Task<bool> GetIsVMHost()
+                => Wmi.ClassExists(Endpoint, "Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor");
 
-                using (var q = Wmi.Query(Endpoint, query))
-                {
-                    var data = await q.GetFirstResultAsync().ConfigureAwait(false);
-                    return data != null;
-                }
-            }
 
             private async Task<string> GetRealAdapterName(string pnpDeviceId)
             {

--- a/Opserver.Core/Monitoring/Wmi.cs
+++ b/Opserver.Core/Monitoring/Wmi.cs
@@ -170,6 +170,9 @@ namespace StackExchange.Opserver.Monitoring
                     return false;
                 }
             }
+
+            public override IEnumerable<string> GetDynamicMemberNames()
+                => _obj.Properties.Cast<PropertyData>().Select(x => x.Name);
         }
     }
 }

--- a/Opserver.Core/Monitoring/Wmi.cs
+++ b/Opserver.Core/Monitoring/Wmi.cs
@@ -89,11 +89,13 @@ namespace StackExchange.Opserver.Monitoring
             private readonly ManagementObjectSearcher _searcher;
             private readonly string _machineName;
             private readonly string _rawQuery;
+            private readonly string _wmiNamespace;
 
             public WmiQuery(string machineName, string q, string wmiNamespace = @"root\cimv2")
             {
                 _machineName = machineName;
                 _rawQuery = q;
+                _wmiNamespace = wmiNamespace;
                 if (machineName.IsNullOrEmpty())
                     throw new ArgumentException("machineName should not be empty.");
 
@@ -113,7 +115,11 @@ namespace StackExchange.Opserver.Monitoring
                         throw new InvalidOperationException("Attempt to use disposed query.");
                     }
 
-                    return _data != null ? Task.FromResult(_data) : Task.Run(() => _data = _searcher.Get());
+                    return _data != null ? Task.FromResult(_data) : Task.Run(() =>
+                    {
+                        try { return _data = _searcher.Get(); }
+                        catch (Exception ex) { throw new Exception($"Failed to query {_wmiNamespace} on {_machineName}", ex); }
+                    });
                 }
             }
 


### PR DESCRIPTION
Querying `Win32_OptionalFeature` seems to equire administrative rights (at least on Server 2012 R2).  Instead of querying installed features, see if the `Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor` class exists.

Also included a small tweak to allow VS to identify the dynamic members in `WmiDynamic`.