### PR TITLE
Add support for linkifying stack traces

### DIFF
--- a/Opserver.Core/Settings/ExceptionSettings.cs
+++ b/Opserver.Core/Settings/ExceptionSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace StackExchange.Opserver
 {
@@ -11,6 +13,8 @@ namespace StackExchange.Opserver
         public List<ExceptionsGroup> Groups { get; set; } = new List<ExceptionsGroup>();
 
         public List<string> Applications { get; set; } = new List<string>();
+
+        public List<StackTraceSourceLinkPattern> StackTraceReplacements { get; set; } = new List<StackTraceSourceLinkPattern>();
 
         /// <summary>
         /// How many exceptions before the exceptions are highlighted as a warning in the header, 0 (default) is ignored
@@ -41,6 +45,7 @@ namespace StackExchange.Opserver
         /// Default maximum timeout in milliseconds before giving up on an sources
         /// </summary>
         public bool EnablePreviews { get; set; } = true;
+
 
         public class ExceptionsGroup : ISettingsCollectionItem
         {
@@ -74,6 +79,53 @@ namespace StackExchange.Opserver
             /// Connection string for this store's database
             /// </summary>
             public string ConnectionString { get; set; }
+        }
+
+        public class StackTraceSourceLinkPattern : ISettingsCollectionItem
+        {
+            /// <summary>
+            /// The name of the deep link pattern.
+            /// </summary>
+            public string Name { get; set; }
+
+            /// <summary>
+            /// A regular expression for detecting links in stack traces.
+            /// Used in conjuction with <see cref="Replacement"/>.
+            /// </summary>
+            public string Pattern { get; set; }
+
+            /// <summary>
+            /// A replacement pattern for rendering links from a <see cref="Pattern"/> match.
+            /// matches via <see cref="System.Text.RegularExpressions.Regex.Replace(string, string, string)"/>.
+            /// </summary>
+            public string Replacement { get; set; }
+
+            private static readonly Regex DontMatchAnything = new Regex("(?!)");
+
+            private Regex _regex;
+            public Regex RegexPattern()
+            {
+                if (_regex == null)
+                {
+                    if (Pattern.HasValue())
+                    {
+                        try
+                        {
+                            _regex = new Regex(Pattern, RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.CultureInvariant);
+                        }
+                        catch (Exception ex)
+                        {
+                            Current.LogException($"Unable to parse source link pattern for '{nameof(Name)}': '{Pattern}'", ex);
+                            _regex = DontMatchAnything;
+                        }
+                    }
+                    else
+                    {
+                        _regex = DontMatchAnything;
+                    }
+                }
+                return _regex;
+            }
         }
     }
 }

--- a/Opserver.Core/Settings/ExceptionSettings.cs
+++ b/Opserver.Core/Settings/ExceptionSettings.cs
@@ -46,7 +46,6 @@ namespace StackExchange.Opserver
         /// </summary>
         public bool EnablePreviews { get; set; } = true;
 
-
         public class ExceptionsGroup : ISettingsCollectionItem
         {
             /// <summary>

--- a/Opserver/Config/ExceptionsSettings.json.example
+++ b/Opserver/Config/ExceptionsSettings.json.example
@@ -70,8 +70,8 @@
   "stackTraceReplacements": [
     {
       "name": "github",
-      "pattern": "",
-      "replacement": "",
+      "pattern": "(?<= in )https?://raw.githubusercontent.com/([^/]+/)([^/]+/)([^/]+/)(.*?):line (\\d+)",
+      "replacement": "<a href=\"https://github.com/$1$2blob/$3$4#L$5\">$4:line $5</a>"
     }
   ]
 }

--- a/Opserver/Config/ExceptionsSettings.json.example
+++ b/Opserver/Config/ExceptionsSettings.json.example
@@ -66,5 +66,12 @@
       "pollIntervalSeconds": 10,
       "connectionString": "Server=ny-sql03.ds.stackexchange.com;Database=NY.Exceptions;Integrated Security=SSPI;"
     }
+  ],
+  "stackTraceReplacements": [
+    {
+      "name": "github",
+      "pattern": "",
+      "replacement": "",
+    }
   ]
 }

--- a/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
+++ b/Opserver/Views/Exceptions/Exceptions.Detail.cshtml
@@ -22,7 +22,6 @@
 }
 @functions
 {
-
     private static readonly HashSet<string> HiddenHttpKeys = new HashSet<string>
     {
         "ALL_HTTP",
@@ -64,6 +63,7 @@
         return url.IsNullOrEmpty() ? url : _sanitizeUrl.Replace(url, "");
     }
 }
+
 @helper Linkify(string possibleLink)
 {
     if (possibleLink.IsNullOrEmpty())
@@ -140,6 +140,66 @@
         </div>
     </div>
 }
+@helper RenderDetail(string detail)
+{
+    var pos = 0;
+    while (pos < detail.Length)
+    {
+        var offset = pos;
+        var matches = Current.Settings.Exceptions.StackTraceReplacements
+            .Select(x => new
+            {
+                pattern = x.RegexPattern(),
+                match = x.RegexPattern().Match(detail, offset),
+                replacement = x.Replacement,
+                name = x.Name,
+            })
+            .Where(x => x.match.Success)
+            .OrderBy(x => x.match.Index)
+            .ThenByDescending(x => x.match.Length)
+            .ToArray();
+
+        if (matches.Length == 0)
+        {
+            break;
+        }
+
+        var next = matches[0];
+
+        var prefixLength =  next.match.Index - pos;
+        if (prefixLength > 0)
+        {
+            Write(detail.Substring(pos, prefixLength));
+        }
+
+        var nextPos = next.match.Index + next.match.Length;
+
+        // log ambigous matches, take first one
+        var overlapping = matches.Skip(1).FirstOrDefault(x => x.match.Index < nextPos);
+        if (overlapping != null)
+        {
+            Current.LogException($"Ambigous source link pattern match between '{next.name}' and '{overlapping.name}'", new Exception("Ambigous SourceLink configuration"));
+        }
+        try
+        {
+            var replacement = next.match.Result(next.replacement);
+            WriteLiteral(replacement); // allow HTML in the replacement
+        }
+        catch (Exception ex)
+        {
+            Current.LogException($"Error while applying source link pattern replacement for '{next.name}'", ex);
+            Write(next.match.Value);
+        }
+
+        pos = nextPos;
+    }
+
+    var tailLength = detail.Length - pos;
+    if (tailLength > 0)
+    {
+        Write(detail.Substring(pos, tailLength));
+    }
+}
 <div id="ErrorInfo">
     @if (error == null)
     {
@@ -165,7 +225,7 @@
         </h5>
         <p class="small text-danger js-error-message">@error.Message</p>
         <div class="error-info">
-            <pre class="pre-code error-detail">@error.Detail.TrimEnd()</pre>
+            <pre class="pre-code error-detail">@RenderDetail(error.Detail)</pre>
             <p class="small">occurred <b title="@error.CreationDate.ToLongDateString() at @error.CreationDate.ToLongTimeString()">@error.CreationDate.ToRelativeTime()</b> (@error.CreationDate.ToZuluTime()) on @error.MachineName
             @if (!error.DeletionDate.HasValue && Current.User.IsExceptionAdmin)
             {


### PR DESCRIPTION
Stack traces will soon contain source link-ed URLs. Since source linked .dll / .pdb files are usually linked to the raw file content, we'd want the link to actually point to web UI for that file. This PR adds support for configuring regex-based replacements to generate deep links to the exact line of a file in the specific commit from the raw URI file. e.g:

```
// Stack trace frame text:
at StackExchange.Opserver.GlobalApplication.RegisterRoutes(RouteTable) in https://raw.githubusercontent.com/opserver/Opserver/f558041474587f094c9b81597de0554f8e77164b/Opserver/Global.asax.cs line 28

// actual URL we want to render:
https://github.com/opserver/Opserver/blob/f558041474587f094c9b81597de0554f8e77164b/Opserver/Global.asax.cs#L28
```
