### PR TITLE
Minor Typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ In order to use Jira
 [Jira action screenshots](http://imgur.com/a/XtW0j)
 
 ### PagerDuty Configuration
-You can connect OpServer to your pagerduty istallation.
+You can connect OpServer to your pagerduty installation.
 
 You need a PagerDuty ReadWrite API Key (RO will work for viewing but will throw errors when you do a RW action). 
 


### PR DESCRIPTION
Changed istallstion -> installation under PagerDuty section. 

It's just a minor one that caught my eye while browsing through the repo, but figured it won't hurt to just fix.