### PR TITLE
Prefer exact match when retrieving dashboard nodes

### DIFF
--- a/Opserver.Core/Data/Dashboard/DashboardModule.cs
+++ b/Opserver.Core/Data/Dashboard/DashboardModule.cs
@@ -61,7 +61,8 @@ namespace StackExchange.Opserver.Data.Dashboard
         public static Node GetNodeByName(string hostName)
         {
             if (!Current.Settings.Dashboard.Enabled || hostName.IsNullOrEmpty()) return null;
-            return AllNodes.Find(s => s.Name.ToLowerInvariant().Contains(hostName.ToLowerInvariant()));
+            return AllNodes.Find(s => s.Name.Equals(hostName, StringComparison.InvariantCultureIgnoreCase)) ??
+				AllNodes.Find(s => s.Name.ToLowerInvariant().Contains(hostName.ToLowerInvariant()));
         }
 
         public static IEnumerable<Node> GetNodesByIP(IPAddress ip) =>


### PR DESCRIPTION
In our environment we have a server whose name is a substring of several other servers (we have several different projects with dedicated servers, e.g. projA-web-1, projB-web-1, projC-web-1, and then a shared server for lots of other small/tiny projects which is just called web-1).  Because that name is a substring of other servers' names, if you click on the link on the dashboard, it finds the wrong node.

I changed it to prefer an exact match, but it will still fall back to the previous behaviour if there is no exact match (I guess this is useful if you're typing in the search box?)