### PR TITLE
SQL Agent Jobs: Handle case where SQL Server is stopped whilst a job is running

### DIFF
--- a/Opserver/Views/SQL/Instance.Jobs.cshtml
+++ b/Opserver/Views/SQL/Instance.Jobs.cshtml
@@ -62,9 +62,16 @@ Last Run Message: @j.LastRunMessage">
                         <td>@(j.LastStopDate?.ToRelativeTimeSpan())</td>
                         <td>@(j.LastRunDuration.HasValue ? j.LastRunDuration.Value.ToTimeStringMini() : "")</td>
                     }
+                    else if (j.LastStartDate.HasValue && !j.LastStopDate.HasValue)
+                    {
+                        <td>@j.LastRunMonitorStatus.IconSpan() @j.LastRunMonitorStatus.Span("Server Stopped whilst Running") (@lastInitiator)</td>
+                        <td>@(j.LastStartDate?.ToRelativeTimeSpan())</td>
+                        <td></td>
+                        <td></td>
+                    }
                     else
                     {
-                        <td colspan="4" class="text-muted">no run history found</td>   
+                        <td colspan="4" class="text-muted">no run history found</td>
                     }
                     <td class="@(j.IsEnabled ? "" : "text-warning")">@(j.IsEnabled ? "Yes" : "No")</td>
                     @if (Current.IsInRole(Roles.SQLAdmin))


### PR DESCRIPTION
Currently, if SQL Server is stopped whilst a job is running, when the server comes back up Opserver shows the job as still running.  
This PR changes that behaviour so that it is says "Server Stopped whilst Running".

Example:  
![sql dashboard - status - mozilla firefox_2](https://user-images.githubusercontent.com/1682204/27324339-d038e982-559c-11e7-9390-6082abe9e358.jpg)

