### PR TITLE
Falling back to category settings for interfaces...

### DIFF
--- a/Opserver.Core/Data/Dashboard/Node.cs
+++ b/Opserver.Core/Data/Dashboard/Node.cs
@@ -286,7 +286,7 @@ namespace StackExchange.Opserver.Data.Dashboard
             {
                 if (_primaryInterfaces == null || (_primaryInterfaces.Count == 0 && Interfaces?.Count > 0))
                 {
-                    var pattern = Settings?.PrimaryInterfacePatternRegex;
+                    var pattern = Settings?.PrimaryInterfacePatternRegex ?? Category?.Settings?.PrimaryInterfacePatternRegex;
                     var dbInterfaces = Interfaces.Where(i => i.IsLikelyPrimary(pattern)).ToList();
                     _primaryInterfaces = (dbInterfaces.Count > 0
                         ? dbInterfaces.OrderBy(i => i.Name)


### PR DESCRIPTION
 if per-node settings are missing.

We were missing primary interface network graphs on the dashboard page since we had configured the interface Regex on a category level and not per-node. This fixes that if the PerNode settings are not found.