### PR TITLE
Automatically log in for EveryonesAnAdminProvider and EveryonesReadOnlyProvider

### DIFF
--- a/Opserver/Controllers/LoginController.cs
+++ b/Opserver/Controllers/LoginController.cs
@@ -3,6 +3,7 @@ using System.Web.Security;
 using StackExchange.Opserver.Helpers;
 using StackExchange.Opserver.Views.Login;
 using Roles = StackExchange.Opserver.Models.Roles;
+using StackExchange.Opserver.Models.Security;
 
 namespace StackExchange.Opserver.Controllers
 {
@@ -13,6 +14,10 @@ namespace StackExchange.Opserver.Controllers
         {
             if (returnUrl == "/")
                 return RedirectToAction(nameof(Login));
+
+            if (Current.Security is EveryonesAnAdminProvider
+                || Current.Security is EveryonesReadOnlyProvider)
+                return View("AutoLogin");
 
             var vd = new LoginModel();
             return View(vd);

--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -635,6 +635,7 @@
     <Content Include="Views\SQL\Databases.Modal.Partitions.cshtml">
       <DependentUpon>Databases.Modal.cshtml</DependentUpon>
     </Content>
+    <Content Include="Views\Login\AutoLogin.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\js\Scripts.js" />

--- a/Opserver/Views/Login/AutoLogin.cshtml
+++ b/Opserver/Views/Login/AutoLogin.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    Layout = null;
+}
+<!DOCTYPE html>
+<html>
+<body onload="document.autoLogin.submit()">
+    <form action="~/login" method="POST" name="autoLogin">
+        <input type="hidden" name="url" value="@Request.QueryString["ReturnUrl"]" />
+    </form>
+</body>
+</html>


### PR DESCRIPTION
When EveryonesAnAdmin or EveryonesReadOnly is selected as the security provider users are redirected to the login page where they are supposed to type random login/password.

This commit introduces custom view which contains auto-submitted form so that users don't need to login.