### PR TITLE
Add total active/inactive counts to node roles api

### DIFF
--- a/Opserver.Core/Data/HAProxy/HAProxyInstance.Roles.cs
+++ b/Opserver.Core/Data/HAProxy/HAProxyInstance.Roles.cs
@@ -13,17 +13,34 @@ namespace StackExchange.Opserver.Data.HAProxy
             foreach (var p in data)
             {
                 if (p.Servers == null) continue;
+                Server found = null;
+                var active = 0;
+                var inactive = 0;
                 foreach (var s in p.Servers)
                 {
                     if (s.Name == node)
                     {
-                        yield return new NodeRole
-                        {
-                            Service = "HAProxy",
-                            Description = $"{Name} - {Group?.Name ?? "(No Group)"} - {p.NiceName}",
-                            Active = s.MonitorStatus == MonitorStatus.Good
-                        };
+                        found = s;
                     }
+                    if (s.MonitorStatus == MonitorStatus.Good)
+                    {
+                        active++;
+                    }
+                    else
+                    {
+                        inactive++;
+                    }
+                }
+                if (found != null)
+                {
+                    yield return new NodeRole
+                    {
+                        Service = "HAProxy",
+                        Description = $"{Name} - {Group?.Name ?? "(No Group)"} - {p.NiceName}",
+                        Active = found.MonitorStatus == MonitorStatus.Good,
+                        TotalActive = active,
+                        TotalInactive = inactive,
+                    };
                 }
             }
         }

--- a/Opserver.Core/Data/NodeRole.cs
+++ b/Opserver.Core/Data/NodeRole.cs
@@ -9,6 +9,8 @@ namespace StackExchange.Opserver.Data
         public string Service { get; set; }
         public string Description { get; set; }
         public bool Active { get; set; }
+        public int TotalActive { get; set; }
+        public int TotalInactive { get; set; }
 
         internal static ConcurrentBag<INodeRoleProvider> Providers { get; } = new ConcurrentBag<INodeRoleProvider>();
 


### PR DESCRIPTION
The node status api currently tells me which backends a given node is a member of, and its' status in each of them. For some use cases (patching), it is necessary to know how many **other** nodes in each backend are up/down. This just adds two more fields `TotalActive` and `TotalInactive` to each NodeRole, and populates it from the HAProxy provider as it iterates over each server anyway.