### PR TITLE
Add check to ensure current user is sysadmin before attempting call to DBCC LOGINFO

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -760,8 +760,9 @@ Open dbs;
 Fetch Next From dbs Into @dbId, @dbName;
 While @@FETCH_STATUS = 0
 Begin
-    Insert Into #vlfTemp
-    Exec('DBCC LOGINFO(''' + @dbName + ''') WITH NO_INFOMSGS');
+    IF IS_SRVROLEMEMBER ('sysadmin') = 1
+       Insert Into #vlfTemp
+       Exec('DBCC LOGINFO(''' + @dbName + ''') WITH NO_INFOMSGS');
     Insert Into #VLFCounts (DatabaseId, DatabaseName, VLFCount)
     Values (@dbId, @dbName, @@ROWCOUNT);
     Truncate Table #vlfTemp;


### PR DESCRIPTION
Very minor change to remove requirement that database user is granted sysadmin.  Users without sysadmin will simply show 0's for the VLF counts.  Ref #303. 