### PR TITLE
Add null check as extra safety measure to ensure class exists and is valid

### DIFF
--- a/Opserver.Core/Monitoring/Wmi.cs
+++ b/Opserver.Core/Monitoring/Wmi.cs
@@ -27,15 +27,13 @@ namespace StackExchange.Opserver.Monitoring
             {
                 using (var q = Query(machineName, query, wmiNamespace))
                 {
-                    await q.GetFirstResultAsync().ConfigureAwait(false);
+                    return (await q.GetFirstResultAsync().ConfigureAwait(false)) != null;
                 }
             }
             catch
             {
                 return false;
             }
-
-            return true;
         }
 
         private static readonly ConnectionOptions _localOptions, _remoteOptions;


### PR DESCRIPTION
Windows Server 2016 was returning null when attempting to check if Win32_PerfRawData_HvStats_HyperVHypervisorLogicalProcessor existed, as the class did exist but had no properties.  This was causing the IsVMHost() check to incorrectly identify 2016 servers as VM Hosts.  Ref #305.