### PR TITLE
Add support for new perNodeSetting called "description".  

### DIFF
--- a/Opserver.Core/Data/Dashboard/Node.cs
+++ b/Opserver.Core/Data/Dashboard/Node.cs
@@ -19,6 +19,7 @@ namespace StackExchange.Opserver.Data.Dashboard
 
         public string Id { get; internal set; }
         public string Name { get; internal set; }
+        public string Description => GetNodeSetting(i => i.Description);
         public DateTime? LastSync { get; internal set; }
         public string MachineType { get; internal set; }
         public string MachineOSVersion { get; internal set; }
@@ -282,6 +283,7 @@ namespace StackExchange.Opserver.Data.Dashboard
         private DashboardSettings.NodeSettings _settings;
         public DashboardSettings.NodeSettings Settings => _settings ?? (_settings = Current.Settings.Dashboard.GetNodeSettings(PrettyName));
 
+        private string GetNodeSetting(Func<DashboardSettings.NodeSettings, string> func) => func(Settings);
         private decimal? GetSetting(Func<INodeSettings, decimal?> func) => func(Settings) ?? func(Category?.Settings) ?? func(Current.Settings.Dashboard);
         private Regex GetSetting(Func<INodeSettings, Regex> func) => func(Settings) ?? func(Category?.Settings) ?? func(Current.Settings.Dashboard);
         public decimal? CPUWarningPercent => GetSetting(i => i.CPUWarningPercent);

--- a/Opserver.Core/Settings/DashboardSettings.cs
+++ b/Opserver.Core/Settings/DashboardSettings.cs
@@ -166,6 +166,11 @@ namespace StackExchange.Opserver
             string ISettingsCollectionItem.Name => Pattern;
 
             /// <summary>
+            /// The description that appears upon hovering over this node
+            /// </summary>
+            public string Description { get; set; }
+
+            /// <summary>
             /// The name that appears for this category
             /// </summary>
             public string Pattern { get; set; }

--- a/Opserver/Views/Dashboard/Dashboard.Table.cshtml
+++ b/Opserver/Views/Dashboard/Dashboard.Table.cshtml
@@ -98,7 +98,7 @@
                         @foreach (var n in g.OrderBy(n => n.PrettyName))
                         {
                             <tr class="@(n.RowClass().Nullify())@(n.IsVM ? " virtual-machine" : null)@(n.IsUnwatched ? " unwatched-row" : null)" data-node="@n.PrettyName">
-                                <td title="@(n.IsVM ? "Virtual Machine hosted on " + (n.VMHost?.PrettyName ?? "Unknown") + " " : null)Last Updated: @(n.LastSync?.ToRelativeTime())">
+                                <td title="@((n.Description.HasValue() ? n.Description + "\x0A" : null) + (n.IsVM ? "Virtual Machine hosted on " + (n.VMHost?.PrettyName ?? "Unknown") + " " : null))Last Updated: @(n.LastSync?.ToRelativeTime())">
                                     @n.IconSpan()
                                     <a href="~/dashboard/node?node=@n.PrettyName" class="@n.TextClass().Nullify()">@n.PrettyName</a>
                                 </td>

--- a/Opserver/Views/Dashboard/Dashboard.Table.cshtml
+++ b/Opserver/Views/Dashboard/Dashboard.Table.cshtml
@@ -98,7 +98,7 @@
                         @foreach (var n in g.OrderBy(n => n.PrettyName))
                         {
                             <tr class="@(n.RowClass().Nullify())@(n.IsVM ? " virtual-machine" : null)@(n.IsUnwatched ? " unwatched-row" : null)" data-node="@n.PrettyName">
-                                <td title="@((n.Description.HasValue() ? n.Description + "\x0A" : null) + (n.IsVM ? "Virtual Machine hosted on " + (n.VMHost?.PrettyName ?? "Unknown") + " " : null))Last Updated: @(n.LastSync?.ToRelativeTime())">
+                                <td title="@(string.Join("\x0A", (new List<string> { n.Description, n.IsVM ? "Virtual Machine hosted on " + (n.VMHost?.PrettyName ?? "Unknown") : null, "Last Updated: " + n.LastSync?.ToRelativeTime() }).Where(s => s.HasValue())))">
                                     @n.IconSpan()
                                     <a href="~/dashboard/node?node=@n.PrettyName" class="@n.TextClass().Nullify()">@n.PrettyName</a>
                                 </td>


### PR DESCRIPTION
Hey Nick, we've got quite a few nodes going on our opserver dashboard now and I've found myself sometimes wishing we had a way to display a brief description of the server(s) if needed.  I know you can argue the categories help, but even with several categories, sometimes it's nice to just have a quick description about the node.

This small change is my attempt at supporting that.  I basically just added a new "description" property in the perNodeSettings that when present, will be prepended onto the title attribute and displayed on hover along with the existing text:

![image](https://user-images.githubusercontent.com/823499/36762808-f78b6ed2-1bea-11e8-8a66-b5ffb78f6c5f.png)

Please take a look and let me know your thoughts.  Thanks!