### PR TITLE
Adding SQL Server 2019 to version list

### DIFF
--- a/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
+++ b/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
@@ -83,6 +83,7 @@ namespace StackExchange.Opserver.Data.SQL
                 {
                     if (Version.HasValue())
                     {
+                        if (Version.StartsWith("15.")) return "SQL 2019";
                         if (Version.StartsWith("14.")) return "SQL 2017";
                         if (Version.StartsWith("13.")) return "SQL 2016";
                         if (Version.StartsWith("12.")) return "SQL 2014";


### PR DESCRIPTION
SQL 2019 is in GA and should be included in the list of versions.