### PR TITLE
C# 8 Changes for .NET Core 3.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)Opserver.ruleset</CodeAnalysisRuleSet>
     <!--<GenerateDocumentationFile>true</GenerateDocumentationFile>-->

--- a/src/Opserver.Core/Data/Cache.cs
+++ b/src/Opserver.Core/Data/Cache.cs
@@ -152,7 +152,7 @@ namespace Opserver.Data
         {
             MiniProfilerDescription = "Poll: " + description; // concatenate once
             // TODO: Settings via owner
-            logExceptions = logExceptions ?? LogExceptions;
+            logExceptions ??= LogExceptions;
 
             _updateFunc = async () =>
             {
@@ -299,8 +299,8 @@ namespace Opserver.Data
         public MiniProfiler Profiler { get; protected set; }
 
         private static IOptions<OpserverSettings> Settings { get; set; }
-        public static bool EnableProfiling => false; // Settings.Value.Global.ProfilePollers;
-        public static bool LogExceptions => false; // Settings.Value.Global.LogPollerExceptions;
+        public static bool EnableProfiling => Settings?.Value.Global.ProfilePollers ?? false;
+        public static bool LogExceptions => Settings?.Value.Global.LogPollerExceptions ?? false;
 
         public static void Configure(IOptions<OpserverSettings> settings) => Settings = settings;
 

--- a/src/Opserver.Core/Data/CloudFlare/CloudFlareAPI.Zones.cs
+++ b/src/Opserver.Core/Data/CloudFlare/CloudFlareAPI.Zones.cs
@@ -10,7 +10,7 @@ namespace Opserver.Data.Cloudflare
     {
         private Cache<List<CloudflareZone>> _zones;
         public Cache<List<CloudflareZone>> Zones =>
-            _zones ?? (_zones = GetCloudflareCache(5.Minutes(), () => Get<List<CloudflareZone>>("zones")));
+            _zones ??= GetCloudflareCache(5.Minutes(), () => Get<List<CloudflareZone>>("zones"));
 
         private static readonly NameValueCollection _dnsRecordFetchParams = new NameValueCollection
         {
@@ -20,7 +20,7 @@ namespace Opserver.Data.Cloudflare
         private Cache<List<CloudflareDNSRecord>> _dnsRecords;
 
         public Cache<List<CloudflareDNSRecord>> DNSRecords =>
-            _dnsRecords ?? (_dnsRecords = GetCloudflareCache(5.Minutes(), async () =>
+            _dnsRecords ??= GetCloudflareCache(5.Minutes(), async () =>
             {
                 var records = new List<CloudflareDNSRecord>();
                 var data = await Zones.GetData(); // wait on zones to load first...
@@ -32,7 +32,7 @@ namespace Opserver.Data.Cloudflare
                     records.AddRange(zoneRecords);
                 }
                 return records;
-            }));
+            });
 
         public CloudflareZone GetZoneFromHost(string host) =>
             Zones.Data?.FirstOrDefault(z => host.EndsWith(z.Name));

--- a/src/Opserver.Core/Data/CloudFlare/CloudFlareAPI.cs
+++ b/src/Opserver.Core/Data/CloudFlare/CloudFlareAPI.cs
@@ -19,12 +19,12 @@ namespace Opserver.Data.Cloudflare
         public override int MinSecondsBetweenPolls => 5;
 
         private Dictionary<string, string> _requestHeaders;
-        private IDictionary<string, string> RequestHeaders => _requestHeaders ?? (_requestHeaders = new Dictionary<string, string>
+        private IDictionary<string, string> RequestHeaders => _requestHeaders ??= new Dictionary<string, string>
         {
             ["X-Auth-Email"] = Email,
             ["X-Auth-Key"] = APIKey,
             ["Content-Type"] = "application/json"
-        });
+        };
 
         public override IEnumerable<Cache> DataPollers
         {

--- a/src/Opserver.Core/Data/CloudFlare/CloudFlareModule.cs
+++ b/src/Opserver.Core/Data/CloudFlare/CloudFlareModule.cs
@@ -55,16 +55,10 @@ namespace Opserver.Data.Cloudflare
         }
 
         private List<IPNet> _maskedRanges;
-        public List<IPNet> MaskedRanges
-        {
-            get
-            {
-                return _maskedRanges ?? (_maskedRanges = Settings.DataCenters?.SelectMany(dc => dc.MaskedRanges)
-                        .Select(r => IPNet.Parse(r))
-                        .ToList()
-                    ?? new List<IPNet>());
-            }
-        }
+        public List<IPNet> MaskedRanges =>
+            _maskedRanges ??= Settings.DataCenters?.SelectMany(dc => dc.MaskedRanges)
+                                                   .Select(r => IPNet.Parse(r))
+                                                   .ToList() ?? new List<IPNet>();
 
         public IEnumerable<string> GetMaskedIPs(List<IPAddress> addresses)
         {

--- a/src/Opserver.Core/Data/Dashboard/HardwareSummary.cs
+++ b/src/Opserver.Core/Data/Dashboard/HardwareSummary.cs
@@ -37,7 +37,7 @@ namespace Opserver.Data.Dashboard
             public string Size { get; internal set; }
             public string PrettyName => Name?.Replace("DIMM_", "");
             private string _bank;
-            public string Bank => _bank ?? (_bank = Name?.TrimEnd(StringSplits.Numbers));
+            public string Bank => _bank ??= Name?.TrimEnd(StringSplits.Numbers);
             private int? _label;
             public int? Label
             {

--- a/src/Opserver.Core/Data/Dashboard/Node.cs
+++ b/src/Opserver.Core/Data/Dashboard/Node.cs
@@ -23,7 +23,7 @@ namespace Opserver.Data.Dashboard
         public string MachineType { get; internal set; }
         public string MachineOSVersion { get; internal set; }
         private string _machineTypePretty;
-        public string MachineTypePretty => _machineTypePretty ?? (_machineTypePretty = GetPrettyMachineType());
+        public string MachineTypePretty => _machineTypePretty ??= GetPrettyMachineType();
         public string Ip { get; internal set; }
         public short? PollIntervalSeconds { get; internal set; }
 
@@ -32,7 +32,7 @@ namespace Opserver.Data.Dashboard
         public NodeStatus? ChildStatus { get; internal set; }
         public string StatusDescription { get; internal set; }
         private HardwareType? _hardwareType;
-        public HardwareType HardwareType => _hardwareType ?? (_hardwareType = GetHardwareType()).Value;
+        public HardwareType HardwareType => _hardwareType ??= GetHardwareType();
 
         public short? CPULoad { get; internal set; }
         public float? TotalMemory { get; internal set; }
@@ -62,7 +62,7 @@ namespace Opserver.Data.Dashboard
 
         private DashboardCategory _category;
         public DashboardCategory Category =>
-            _category ?? (_category = DataProvider.Module.AllCategories.Find(c => c.PatternRegex.IsMatch(Name)) ?? DashboardCategory.Unknown);
+            _category ??= DataProvider.Module.AllCategories.Find(c => c.PatternRegex.IsMatch(Name)) ?? DashboardCategory.Unknown;
         private string GetPrettyMachineType()
         {
             if (MachineType?.StartsWith("Linux") ?? false) return MachineOSVersion.IsNullOrEmptyReturn("Linux");
@@ -280,7 +280,7 @@ namespace Opserver.Data.Dashboard
         public float TotalVolumePerformancebps => Volumes?.Sum(i => i.ReadBps.GetValueOrDefault(0) + i.WriteBps.GetValueOrDefault(0)) ?? 0;
 
         private DashboardSettings.NodeSettings _settings;
-        public DashboardSettings.NodeSettings Settings => _settings ?? (_settings = DataProvider.Module.Settings.GetNodeSettings(PrettyName));
+        public DashboardSettings.NodeSettings Settings => _settings ??= DataProvider.Module.Settings.GetNodeSettings(PrettyName);
 
         private decimal? GetSetting(Func<INodeSettings, decimal?> func) => func(Settings) ?? func(Category?.Settings) ?? func(DataProvider.Module.Settings);
         private Regex GetSetting(Func<INodeSettings, Regex> func) => func(Settings) ?? func(Category?.Settings) ?? func(DataProvider.Module.Settings);

--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Metrics.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Metrics.cs
@@ -79,7 +79,7 @@ namespace Opserver.Data.Dashboard.Providers
         {
             get
             {
-                return _dayCache ?? (_dayCache = ProviderCache(async () =>
+                return _dayCache ??= ProviderCache(async () =>
                 {
                     var result = new IntervalCache(TimeSpan.FromDays(1));
                     async Task addMetric(string metricName, string[] tags)
@@ -105,7 +105,7 @@ namespace Opserver.Data.Dashboard.Providers
                     await Task.WhenAll(c, m, n); // parallel baby!
 
                     return result;
-                }, 60.Seconds(), 60.Minutes()));
+                }, 60.Seconds(), 60.Minutes());
             }
         }
 
@@ -301,11 +301,11 @@ namespace Opserver.Data.Dashboard.Providers
         public List<float[]> Data { get; set; }
 
         private List<GraphPoint> _pointData;
-        public List<GraphPoint> PointData => _pointData ?? (_pointData = Data.Select(p => new GraphPoint
+        public List<GraphPoint> PointData => _pointData ??= Data.Select(p => new GraphPoint
         {
             DateEpoch = (long) p[0],
             Value = p[1]
-        }).ToList());
+        }).ToList();
 
         public PointSeries() { }
         public PointSeries(string host)

--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Metrics.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Metrics.cs
@@ -203,22 +203,15 @@ namespace Opserver.Data.Dashboard.Providers
             }
         }
 
-        public static string InterfaceMetricName(Interface i)
-        {
-            switch (i.TypeDescription)
+        public static string InterfaceMetricName(Interface i) =>
+            i.TypeDescription switch
             {
-                case "bond":
-                    return Globals.NetBondBytes;
-                case "other":
-                    return Globals.NetOtherBytes;
-                case "tunnel":
-                    return Globals.NetTunnelBytes;
-                case "virtual":
-                    return Globals.NetVirtualBytes;
-                default:
-                    return Globals.NetBytes;
-            }
-        }
+                "bond" => Globals.NetBondBytes,
+                "other" => Globals.NetOtherBytes,
+                "tunnel" => Globals.NetTunnelBytes,
+                "virtual" => Globals.NetVirtualBytes,
+                _ => Globals.NetBytes,
+            };
 
         public static string GetDenormalized(string metric, string host, Dictionary<string, List<string>> metricCache)
         {

--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Nodes.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Nodes.cs
@@ -301,21 +301,14 @@ namespace Opserver.Data.Dashboard.Providers
             }
         }
 
-        private static MonitorStatus GetStatusFromString(string status)
-        {
-            switch (status)
+        private static MonitorStatus GetStatusFromString(string status) =>
+            status switch
             {
-                case "critical":
-                    return MonitorStatus.Critical;
-                case "normal":
-                    return MonitorStatus.Good;
-                case "warning":
-                    return MonitorStatus.Warning;
-                default:
-                    //case "unknown":
-                    return MonitorStatus.Unknown;
-            }
-        }
+                "critical" => MonitorStatus.Critical,
+                "normal" => MonitorStatus.Good,
+                "warning" => MonitorStatus.Warning,
+                _ => MonitorStatus.Unknown,//case "unknown":
+            };
 
         private NodeStatus GetNodeStatus(BosunHost host)
         {

--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Nodes.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.Nodes.cs
@@ -9,17 +9,17 @@ namespace Opserver.Data.Dashboard.Providers
     public partial class BosunDataProvider
     {
         private Cache<List<Node>> _nodeCache;
-        public Cache<List<Node>> NodeCache => _nodeCache ?? (_nodeCache = ProviderCache(GetAllNodesAsync, 60.Seconds(), 4.Hours()));
+        public Cache<List<Node>> NodeCache => _nodeCache ??= ProviderCache(GetAllNodesAsync, 60.Seconds(), 4.Hours());
 
         private Cache<Dictionary<string, List<string>>> _nodeMetricCache;
 
         public Cache<Dictionary<string, List<string>>> NodeMetricCache
-            => _nodeMetricCache ?? (_nodeMetricCache = ProviderCache(
+            => _nodeMetricCache ??= ProviderCache(
                 async () =>
                 {
                     var response = await GetFromBosunAsync<Dictionary<string, List<string>>>(GetUrl("api/metric/host"));
                     return response.Result ?? new Dictionary<string, List<string>>();
-                }, 10.Minutes(), 4.Hours()));
+                }, 10.Minutes(), 4.Hours());
 
         public async Task<List<Node>> GetAllNodesAsync()
         {

--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.cs
@@ -60,12 +60,10 @@ namespace Opserver.Data.Dashboard.Providers
                         wc.Headers.Add("X-Access-Token", Settings.APIKey);
                     }
 
-                    using (var s = await wc.OpenReadTaskAsync(url))
-                    using (var sr = new StreamReader(s))
-                    {
-                        var result = JSON.Deserialize<T>(sr, Options.SecondsSinceUnixEpochExcludeNullsUtc);
-                        return new BosunApiResult<T> { Result = result };
-                    }
+                    using var s = await wc.OpenReadTaskAsync(url);
+                    using var sr = new StreamReader(s);
+                    var result = JSON.Deserialize<T>(sr, Options.SecondsSinceUnixEpochExcludeNullsUtc);
+                    return new BosunApiResult<T> { Result = result };
                 }
                 catch (DeserializationException de)
                 {

--- a/src/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
@@ -29,7 +29,7 @@ namespace Opserver.Data.Dashboard.Providers
         public override List<Node> AllNodes => NodeCache.Data ?? new List<Node>();
 
         private Cache<List<Node>> _nodeCache;
-        public Cache<List<Node>> NodeCache => _nodeCache ?? (_nodeCache = ProviderCache(GetAllNodesAsync, 10.Seconds()));
+        public Cache<List<Node>> NodeCache => _nodeCache ??= ProviderCache(GetAllNodesAsync, 10.Seconds());
 
         public async Task<List<Node>> GetAllNodesAsync()
         {

--- a/src/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/OrionDataProvider.cs
@@ -35,9 +35,8 @@ namespace Opserver.Data.Dashboard.Providers
         {
             using (MiniProfiler.Current.Step("Get Server Nodes"))
             {
-                using (var conn = await GetConnectionAsync())
-                {
-                    var nodes = await conn.QueryAsync<Node>(@"
+                using var conn = await GetConnectionAsync();
+                var nodes = await conn.QueryAsync<Node>(@"
 Select Cast(n.NodeID as varchar(50)) as Id,
        Caption as Name,
        LastSync,
@@ -65,7 +64,7 @@ Select Cast(n.NodeID as varchar(50)) as Id,
  Where LastSync Is Not Null
  Order By Id, Caption", commandTimeout: QueryTimeoutMs);
 
-                    var interfaces = await conn.QueryAsync<Interface>(@"
+                var interfaces = await conn.QueryAsync<Interface>(@"
 Select Cast(InterfaceID as varchar(50)) as Id,
        Cast(NodeID as varchar(50)) as NodeId,
        LastSync,
@@ -85,7 +84,7 @@ Select Cast(InterfaceID as varchar(50)) as Id,
        InterfaceSpeed as Speed
 From Interfaces", commandTimeout: QueryTimeoutMs);
 
-                    var volumes = await conn.QueryAsync<Volume>(@"
+                var volumes = await conn.QueryAsync<Volume>(@"
 Select Cast(VolumeID as varchar(50)) as Id,
        Cast(NodeID as varchar(50)) as NodeId,
        LastSync,
@@ -101,7 +100,7 @@ Select Cast(VolumeID as varchar(50)) as Id,
   From Volumes
  Where VolumeType = 'Fixed Disk'", commandTimeout: QueryTimeoutMs);
 
-                    var apps = await conn.QueryAsync<Application>(@"
+                var apps = await conn.QueryAsync<Application>(@"
 Select Cast(com.ApplicationID as varchar(50)) as Id, 
        Cast(NodeID as varchar(50)) as NodeId, 
        app.Name as AppName, 
@@ -129,45 +128,45 @@ From APM_Application app
        On ccs.ComponentStatusID = pe.ComponentStatusID
 Order By NodeID", commandTimeout: QueryTimeoutMs);
 
-                    foreach (var a in apps)
+                foreach (var a in apps)
+                {
+                    a.NiceName = a.ComponentName == "Process Monitor - WMI" || a.ComponentName == "Wrapper Process"
+                        ? a.AppName
+                        : (a.ComponentName ?? "").Replace(" IIS App Pool", "");
+                }
+
+                var ips = await GetNodeIPMapAsync(conn);
+
+                foreach (var i in interfaces)
+                {
+                    i.IPs = ips.Where(ip => i.Id == ip.InterfaceID && ip.IPNet != null).Select(ip => ip.IPNet).ToList();
+                }
+
+                var exclude = Module.Settings.ExcludePatternRegex;
+                if (exclude != null)
+                {
+                    nodes = nodes.Where(n => !exclude.IsMatch(n.Name) || (n.IsVMHost && nodes.Any(x => x.VMHostID == n.Id))).ToList();
+                }
+
+                foreach (var n in nodes)
+                {
+                    n.DataProvider = this;
+                    n.ManagementUrl = GetManagementUrl(n);
+                    n.Interfaces = interfaces.Where(i => i.NodeId == n.Id).ToList();
+                    n.Volumes = volumes.Where(v => v.NodeId == n.Id).ToList();
+                    n.Apps = apps.Where(a => a.NodeId == n.Id).ToList();
+                    n.VMs = nodes.Where(on => on.VMHostID == n.Id).ToList();
+                    n.VMHost = nodes.Find(on => n.VMHostID == on.Id);
+                    n.SetReferences();
+
+                    if (Settings.ChildStatusForHealthy && n.Status == NodeStatus.Up && n.ChildStatus.HasValue)
                     {
-                        a.NiceName = a.ComponentName == "Process Monitor - WMI" || a.ComponentName == "Wrapper Process"
-                            ? a.AppName
-                            : (a.ComponentName ?? "").Replace(" IIS App Pool", "");
+                        n.Status = n.ChildStatus.Value;
                     }
 
-                    var ips = await GetNodeIPMapAsync(conn);
-
-                    foreach (var i in interfaces)
+                    if (n.Status != NodeStatus.Up)
                     {
-                        i.IPs = ips.Where(ip => i.Id == ip.InterfaceID && ip.IPNet != null).Select(ip => ip.IPNet).ToList();
-                    }
-
-                    var exclude = Module.Settings.ExcludePatternRegex;
-                    if (exclude != null)
-                    {
-                        nodes = nodes.Where(n => !exclude.IsMatch(n.Name) || (n.IsVMHost && nodes.Any(x => x.VMHostID == n.Id))).ToList();
-                    }
-
-                    foreach (var n in nodes)
-                    {
-                        n.DataProvider = this;
-                        n.ManagementUrl = GetManagementUrl(n);
-                        n.Interfaces = interfaces.Where(i => i.NodeId == n.Id).ToList();
-                        n.Volumes = volumes.Where(v => v.NodeId == n.Id).ToList();
-                        n.Apps = apps.Where(a => a.NodeId == n.Id).ToList();
-                        n.VMs = nodes.Where(on => on.VMHostID == n.Id).ToList();
-                        n.VMHost = nodes.Find(on => n.VMHostID == on.Id);
-                        n.SetReferences();
-
-                        if (Settings.ChildStatusForHealthy && n.Status == NodeStatus.Up && n.ChildStatus.HasValue)
-                        {
-                            n.Status = n.ChildStatus.Value;
-                        }
-
-                        if (n.Status != NodeStatus.Up)
-                        {
-                            n.Issues = new List<Issue<Node>>
+                        n.Issues = new List<Issue<Node>>
                             {
                                 new Issue<Node>(n, "Orion", n.PrettyName)
                                 {
@@ -176,11 +175,10 @@ Order By NodeID", commandTimeout: QueryTimeoutMs);
                                     MonitorStatus = n.Status.ToMonitorStatus()
                                 }
                             };
-                        }
                     }
-
-                    return nodes;
                 }
+
+                return nodes;
             }
         }
 
@@ -308,14 +306,12 @@ Select DateDiff(s, '1970-01-01', itd.DateTime) as DateEpoch,
 
             if (node.PrimaryInterfaces.Count == 0) return new List<DoubleGraphPoint>();
 
-            using (var conn = await GetConnectionAsync())
-            {
-                var result = await conn.QueryAsync<Interface.InterfaceUtilization>(
-                    (pointCount.HasValue ? sampledSql : allSql)
-                        .Replace("{dateRange}", GetOptionalDateClause("itd.DateTime", start, end)),
-                    new { Ids = node.PrimaryInterfaces.Select(i => int.Parse(i.Id)), start, end, intervals = pointCount });
-                return result.ToList<DoubleGraphPoint>();
-            }
+            using var conn = await GetConnectionAsync();
+            var result = await conn.QueryAsync<Interface.InterfaceUtilization>(
+(pointCount.HasValue ? sampledSql : allSql)
+.Replace("{dateRange}", GetOptionalDateClause("itd.DateTime", start, end)),
+new { Ids = node.PrimaryInterfaces.Select(i => int.Parse(i.Id)), start, end, intervals = pointCount });
+            return result.ToList<DoubleGraphPoint>();
         }
 
         public override async Task<List<DoubleGraphPoint>> GetVolumePerformanceUtilizationAsync(Node node, DateTime? start, DateTime? end, int? pointCount = null)
@@ -349,14 +345,12 @@ Select DateDiff(s, '1970-01-01', vp.DateTime) as DateEpoch,
  Group By vp.DateTime
  Order By vp.DateTime";
 
-            using (var conn = await GetConnectionAsync())
-            {
-                var result = await conn.QueryAsync<Volume.VolumePerformanceUtilization>(
-                    (pointCount.HasValue ? sampledSql : allSql)
-                        .Replace("{dateRange}", GetOptionalDateClause("vp.DateTime", start, end)),
-                    new { Ids = node.Volumes.Select(v => int.Parse(v.Id)), start, end, intervals = pointCount });
-                return result.ToList<DoubleGraphPoint>();
-            }
+            using var conn = await GetConnectionAsync();
+            var result = await conn.QueryAsync<Volume.VolumePerformanceUtilization>(
+(pointCount.HasValue ? sampledSql : allSql)
+.Replace("{dateRange}", GetOptionalDateClause("vp.DateTime", start, end)),
+new { Ids = node.Volumes.Select(v => int.Parse(v.Id)), start, end, intervals = pointCount });
+            return result.ToList<DoubleGraphPoint>();
         }
 
         public override async Task<List<DoubleGraphPoint>> GetPerformanceUtilizationAsync(Volume volume, DateTime? start, DateTime? end, int? pointCount = null)
@@ -468,13 +462,11 @@ Select DateDiff(s, '1970-01-01 00:00:00', itd.DateTime) as DateEpoch,
 
         private async Task<List<T>> UtilizationQueryAsync<T>(string id, string allSql, string sampledSql, string dateField, DateTime? start, DateTime? end, int? pointCount) where T : IGraphPoint
         {
-            using (var conn = await GetConnectionAsync())
-            {
-                return await conn.QueryAsync<T>(
-                    (pointCount.HasValue ? sampledSql : allSql)
-                        .Replace("{dateRange}", GetOptionalDateClause(dateField, start, end)),
-                    new { id = int.Parse(id), start, end, intervals = pointCount });
-            }
+            using var conn = await GetConnectionAsync();
+            return await conn.QueryAsync<T>(
+(pointCount.HasValue ? sampledSql : allSql)
+.Replace("{dateRange}", GetOptionalDateClause(dateField, start, end)),
+new { id = int.Parse(id), start, end, intervals = pointCount });
         }
     }
 }

--- a/src/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/WmiDataProvider.Polling.cs
@@ -368,18 +368,12 @@ SELECT Caption,
                         s.Name = service.Name;
                         s.State = service.State;
                         s.LastSync = DateTime.UtcNow;
-                        switch (service.State)
+                        s.Status = service.State switch
                         {
-                            case "Running":
-                                s.Status = NodeStatus.Active;
-                                break;
-                            case "Stopped":
-                                s.Status = NodeStatus.Down;
-                                break;
-                            default:
-                                s.Status = NodeStatus.Unknown;
-                                break;
-                        }
+                            "Running" => NodeStatus.Active,
+                            "Stopped" => NodeStatus.Down,
+                            _ => NodeStatus.Unknown,
+                        };
                         s.Running = service.Started;
                         s.StartMode = service.StartMode;
                         s.StartName = service.StartName;
@@ -580,17 +574,12 @@ SELECT Caption,
                 {
                     foreach (var service in await q.GetDynamicResultAsync())
                     {
-                        switch (action)
+                        returnCode = action switch
                         {
-                            case NodeService.Action.Stop:
-                                returnCode = service.StopService();
-                                break;
-                            case NodeService.Action.Start:
-                                returnCode = service.StartService();
-                                break;
-                            default:
-                                throw new ArgumentOutOfRangeException(nameof(action));
-                        }
+                            NodeService.Action.Stop => service.StopService(),
+                            NodeService.Action.Start => service.StartService(),
+                            _ => throw new ArgumentOutOfRangeException(nameof(action)),
+                        };
                     }
                 }
 

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.Aliases.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.Aliases.cs
@@ -8,7 +8,7 @@ namespace Opserver.Data.Elastic
     {
         private Cache<IndexAliasInfo> _aliases;
         public Cache<IndexAliasInfo> Aliases =>
-            _aliases ?? (_aliases = GetElasticCache(async () =>
+            _aliases ??= GetElasticCache(async () =>
             {
                 var aliases = await GetAsync<Dictionary<string, IndexAliasList>>("_aliases");
                 return new IndexAliasInfo
@@ -17,14 +17,14 @@ namespace Opserver.Data.Elastic
                         .ToDictionary(a => a.Key, a => a.Value.Aliases.Keys.ToList())
                               ?? new Dictionary<string, List<string>>()
                 };
-            }));
+            });
 
         public string GetIndexAliasedName(string index)
         {
             if (Aliases.Data?.Aliases == null)
                 return index;
 
-            return Aliases.Data.Aliases.TryGetValue(index, out List<string> aliases)
+            return Aliases.Data.Aliases.TryGetValue(index, out var aliases)
                        ? aliases[0].IsNullOrEmptyReturn(index)
                        : index;
         }

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.HealthStatus.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.HealthStatus.cs
@@ -9,10 +9,9 @@ namespace Opserver.Data.Elastic
     {
         private Cache<ClusterHealthInfo> _healthStatus;
         public Cache<ClusterHealthInfo> HealthStatus =>
-            _healthStatus ?? (_healthStatus = GetElasticCache(
+            _healthStatus ??= GetElasticCache(
                     async () => (await GetAsync<ClusterHealthInfo>("_cluster/health?level=shards"))?.Prep()
-                )
-            );
+                );
 
         /// <summary>
         /// The Index info API changes in ElasticSearch 0.9, it's not really reasonable to support 

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.IndexStats.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.IndexStats.cs
@@ -7,9 +7,7 @@ namespace Opserver.Data.Elastic
     {
         private Cache<IndexStatsInfo> _indexStats;
         public Cache<IndexStatsInfo> IndexStats =>
-            _indexStats ?? (_indexStats = GetElasticCache(
-                () => GetAsync<IndexStatsInfo>("_stats"))
-            );
+            _indexStats ??= GetElasticCache(() => GetAsync<IndexStatsInfo>("_stats"));
 
         public class IndexStatsInfo
         {

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.Nodes.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.Nodes.cs
@@ -11,7 +11,7 @@ namespace Opserver.Data.Elastic
     {
         private Cache<ClusterNodesInfo> _nodes;
         public Cache<ClusterNodesInfo> Nodes =>
-            _nodes ?? (_nodes = GetElasticCache(async () =>
+            _nodes ??= GetElasticCache(async () =>
             {
                 var resultTask = GetAsync<ClusterNodesInfo>("_nodes");
                 // Note without ?all, we have dropped support for < v0.90
@@ -32,7 +32,7 @@ namespace Opserver.Data.Elastic
                     }
                 }
                 return result;
-            }));
+            });
 
         public string Name => Nodes.Data?.Name ?? SettingsName;
         public string ShortName(NodeInfo node) => node?.Name.TrimEnd("-" + Name);
@@ -74,7 +74,7 @@ namespace Opserver.Data.Elastic
 
             //private Version _version;
             //[IgnoreDataMember]
-            //public Version Version => _version ?? (_version = VersionString.HasValue() ? Version.Parse(VersionString) : new Version("0.0"));
+            //public Version Version => _version ??= VersionString.HasValue() ? Version.Parse(VersionString) : new Version("0.0");
 
             [IgnoreDataMember]
             public string Version => VersionString;
@@ -208,7 +208,7 @@ namespace Opserver.Data.Elastic
                 [DataMember(Name = "max_content_length_in_bytes")] public long MaxContentLengthInBytes { get; internal set; }
 
                 private string _publishPrettyAddress;
-                public string PublishAddressPretty => _publishPrettyAddress ?? (_publishPrettyAddress = _inetStrip.Replace(PublishAddress, "$1"));
+                public string PublishAddressPretty => _publishPrettyAddress ??= _inetStrip.Replace(PublishAddress, "$1");
             }
         }
 

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.State.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.State.cs
@@ -91,67 +91,37 @@ namespace Opserver.Data.Elastic
 
             public class ShardState : IMonitorStatus
             {
-                public MonitorStatus MonitorStatus
-                {
-                    get
+                public MonitorStatus MonitorStatus =>
+                    State switch
                     {
-                        switch (State)
-                        {
-                            case ShardStates.Unassigned:
-                                return MonitorStatus.Critical;
-                            case ShardStates.Initializing:
-                                return MonitorStatus.Warning;
-                            case ShardStates.Started:
-                                return MonitorStatus.Good;
-                            case ShardStates.Relocating:
-                                return MonitorStatus.Maintenance;
-                            default:
-                                return MonitorStatus.Unknown;
-                        }
-                    }
-                }
+                        ShardStates.Unassigned => MonitorStatus.Critical,
+                        ShardStates.Initializing => MonitorStatus.Warning,
+                        ShardStates.Started => MonitorStatus.Good,
+                        ShardStates.Relocating => MonitorStatus.Maintenance,
+                        _ => MonitorStatus.Unknown,
+                    };
 
                 public string MonitorStatusReason => StateDescription;
 
-                public string StateDescription
-                {
-                    get
+                public string StateDescription =>
+                    State switch
                     {
-                        switch (State)
-                        {
-                            case ShardStates.Unassigned:
-                                return "The shard is not assigned to any node";
-                            case ShardStates.Initializing:
-                                return "The shard is initializing (probably recovering from either a peer shard or gateway)";
-                            case ShardStates.Started:
-                                return "The shard is started";
-                            case ShardStates.Relocating:
-                                return "The shard is in the process being relocated";
-                            default:
-                                return "Unknown";
-                        }
-                    }
-                }
+                        ShardStates.Unassigned => "The shard is not assigned to any node",
+                        ShardStates.Initializing => "The shard is initializing (probably recovering from either a peer shard or gateway)",
+                        ShardStates.Started => "The shard is started",
+                        ShardStates.Relocating => "The shard is in the process being relocated",
+                        _ => "Unknown",
+                    };
 
-                public string PrettyState
-                {
-                    get
+                public string PrettyState =>
+                    State switch
                     {
-                        switch (State)
-                        {
-                            case ShardStates.Unassigned:
-                                return "Unassigned";
-                            case ShardStates.Initializing:
-                                return "Initializing";
-                            case ShardStates.Started:
-                                return "Started";
-                            case ShardStates.Relocating:
-                                return "Relocating";
-                            default:
-                                return "Unknown";
-                        }
-                    }
-                }
+                        ShardStates.Unassigned => "Unassigned",
+                        ShardStates.Initializing => "Initializing",
+                        ShardStates.Started => "Started",
+                        ShardStates.Relocating => "Relocating",
+                        _ => "Unknown",
+                    };
 
                 [DataMember(Name = "state")]
                 public string State { get; internal set; }

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.State.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.State.cs
@@ -8,8 +8,8 @@ namespace Opserver.Data.Elastic
     {
         private Cache<ClusterStateInfo> _state;
 
-        public Cache<ClusterStateInfo> State => _state ?? (_state = GetElasticCache(
-            () => GetAsync<ClusterStateInfo>("_cluster/state/version,master_node,nodes,routing_table,routing_nodes/"))
+        public Cache<ClusterStateInfo> State => _state ??= GetElasticCache(
+            () => GetAsync<ClusterStateInfo>("_cluster/state/version,master_node,nodes,routing_table,routing_nodes/")
         );
 
         public NodeInfo MasterNode => Nodes.Data?.Nodes?.FirstOrDefault(n => State?.Data?.MasterNode == n.GUID);
@@ -21,9 +21,9 @@ namespace Opserver.Data.Elastic
         {
             private MonitorStatus? _monitorStatus;
             public MonitorStatus MonitorStatus =>
-                _monitorStatus ?? (_monitorStatus = RoutingNodes?.Nodes.Values.SelectMany(n => n)
+                _monitorStatus ??= RoutingNodes?.Nodes.Values.SelectMany(n => n)
                     .Union(RoutingNodes.Unassigned)
-                    .GetWorstStatus() ?? MonitorStatus.Unknown).Value;
+                    .GetWorstStatus() ?? MonitorStatus.Unknown;
             // TODO: Implement
             public string MonitorStatusReason => null;
 

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
@@ -12,7 +12,7 @@ namespace Opserver.Data.Elastic
         string ISearchableNode.Name => SettingsName;
         string ISearchableNode.DisplayName => SettingsName;
         private TimeSpan? _refreshInteval;
-        public TimeSpan RefreshInterval => _refreshInteval ?? (_refreshInteval = Settings.RefreshIntervalSeconds.Seconds()).Value;
+        public TimeSpan RefreshInterval => _refreshInteval ??= Settings.RefreshIntervalSeconds.Seconds();
         string ISearchableNode.CategoryName => "elastic";
         public ElasticSettings.Cluster Settings { get; }
         private string SettingsName => Settings.Name;

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
@@ -116,20 +116,14 @@ namespace Opserver.Data.Elastic
             return null;
         }
 
-        private static MonitorStatus ColorToStatus(string color)
-        {
-            switch (color)
+        private static MonitorStatus ColorToStatus(string color) =>
+            color switch
             {
-                case "green":
-                    return MonitorStatus.Good;
-                case "yellow":
-                    return MonitorStatus.Warning;
-                case "red":
-                    return MonitorStatus.Critical;
-                default:
-                    return MonitorStatus.Unknown;
-            }
-        }
+                "green" => MonitorStatus.Good,
+                "yellow" => MonitorStatus.Warning,
+                "red" => MonitorStatus.Critical,
+                _ => MonitorStatus.Unknown,
+            };
 
         public override string ToString() => SettingsName;
     }

--- a/src/Opserver.Core/Data/Exceptions/Application.cs
+++ b/src/Opserver.Core/Data/Exceptions/Application.cs
@@ -21,7 +21,7 @@ namespace Opserver.Data.Exceptions
         private static readonly Regex _shortLogStripRegex = new Regex(@"[^A-Za-z_0-9_\-_\.\/]", RegexOptions.Compiled);
         private string _shortName;
 
-        public string ShortName => _shortName ?? (_shortName = _shortLogStripRegex.Replace(Name, ""));
+        public string ShortName => _shortName ??= _shortLogStripRegex.Replace(Name, "");
 
         public JSONApplication ToJSON()
         {

--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -83,7 +83,7 @@ namespace Opserver.Data.Exceptions
 
         private Cache<List<Application>> _applications;
         public Cache<List<Application>> Applications =>
-            _applications ?? (_applications = new Cache<List<Application>>(
+            _applications ??= new Cache<List<Application>>(
                 this,
                 "Exceptions Fetch: " + Name + ":" + nameof(Applications),
                 Settings.PollIntervalSeconds.Seconds(),
@@ -104,7 +104,7 @@ Select ApplicationName as Name,
                     });
                     return result;
                 },
-                afterPoll: _ => UpdateApplicationGroups()));
+                afterPoll: _ => UpdateApplicationGroups());
 
         internal List<ApplicationGroup> UpdateApplicationGroups()
         {

--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -318,49 +318,29 @@ Select e.Id,
             }
         }
 
-        private static string GetSortString(ExceptionSorts sort)
-        {
-            switch (sort)
+        private static string GetSortString(ExceptionSorts sort) =>
+            sort switch
             {
-                case ExceptionSorts.AppAsc:
-                    return " Order By ApplicationName, CreationDate Desc";
-                case ExceptionSorts.AppDesc:
-                    return " Order By ApplicationName Desc, CreationDate Desc";
-                case ExceptionSorts.TypeAsc:
-                    return " Order By Right(e.Type, charindex('.', reverse(e.Type) + '.') - 1), CreationDate Desc";
-                case ExceptionSorts.TypeDesc:
-                    return " Order By Right(e.Type, charindex('.', reverse(e.Type) + '.') - 1) Desc, CreationDate Desc";
-                case ExceptionSorts.MessageAsc:
-                    return " Order By Message, CreationDate Desc";
-                case ExceptionSorts.MessageDesc:
-                    return " Order By Message Desc, CreationDate Desc";
-                case ExceptionSorts.UrlAsc:
-                    return " Order By Url, CreationDate Desc";
-                case ExceptionSorts.UrlDesc:
-                    return " Order By Url Desc, CreationDate Desc";
-                case ExceptionSorts.IPAddressAsc:
-                    return " Order By IPAddress, CreationDate Desc";
-                case ExceptionSorts.IPAddressDesc:
-                    return " Order By IPAddress Desc, CreationDate Desc";
-                case ExceptionSorts.HostAsc:
-                    return " Order By Host, CreationDate Desc";
-                case ExceptionSorts.HostDesc:
-                    return " Order By Host Desc, CreationDate Desc";
-                case ExceptionSorts.MachineNameAsc:
-                    return " Order By MachineName, CreationDate Desc";
-                case ExceptionSorts.MachineNameDesc:
-                    return " Order By MachineName Desc, CreationDate Desc";
-                case ExceptionSorts.CountAsc:
-                    return " Order By IsNull(DuplicateCount, 1), CreationDate Desc";
-                case ExceptionSorts.CountDesc:
-                    return " Order By IsNull(DuplicateCount, 1) Desc, CreationDate Desc";
-                case ExceptionSorts.TimeAsc:
-                    return " Order By CreationDate";
+                ExceptionSorts.AppAsc => " Order By ApplicationName, CreationDate Desc",
+                ExceptionSorts.AppDesc => " Order By ApplicationName Desc, CreationDate Desc",
+                ExceptionSorts.TypeAsc => " Order By Right(e.Type, charindex('.', reverse(e.Type) + '.') - 1), CreationDate Desc",
+                ExceptionSorts.TypeDesc => " Order By Right(e.Type, charindex('.', reverse(e.Type) + '.') - 1) Desc, CreationDate Desc",
+                ExceptionSorts.MessageAsc => " Order By Message, CreationDate Desc",
+                ExceptionSorts.MessageDesc => " Order By Message Desc, CreationDate Desc",
+                ExceptionSorts.UrlAsc => " Order By Url, CreationDate Desc",
+                ExceptionSorts.UrlDesc => " Order By Url Desc, CreationDate Desc",
+                ExceptionSorts.IPAddressAsc => " Order By IPAddress, CreationDate Desc",
+                ExceptionSorts.IPAddressDesc => " Order By IPAddress Desc, CreationDate Desc",
+                ExceptionSorts.HostAsc => " Order By Host, CreationDate Desc",
+                ExceptionSorts.HostDesc => " Order By Host Desc, CreationDate Desc",
+                ExceptionSorts.MachineNameAsc => " Order By MachineName, CreationDate Desc",
+                ExceptionSorts.MachineNameDesc => " Order By MachineName Desc, CreationDate Desc",
+                ExceptionSorts.CountAsc => " Order By IsNull(DuplicateCount, 1), CreationDate Desc",
+                ExceptionSorts.CountDesc => " Order By IsNull(DuplicateCount, 1) Desc, CreationDate Desc",
+                ExceptionSorts.TimeAsc => " Order By CreationDate",
                 //case ExceptionSorts.TimeDesc:
-                default:
-                    return " Order By CreationDate Desc";
-            }
-        }
+                _ => " Order By CreationDate Desc",
+            };
 
         public Task<int> DeleteErrorsAsync(SearchParams search)
         {

--- a/src/Opserver.Core/Data/HAProxy/HAProxyAdmin.cs
+++ b/src/Opserver.Core/Data/HAProxy/HAProxyAdmin.cs
@@ -96,20 +96,18 @@ namespace Opserver.Data.HAProxy
 
             try
             {
-                using (var wc = new WebClient())
-                {
-                    var creds = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{instance.AdminUser}:{instance.AdminPassword}"));
-                    wc.Headers[HttpRequestHeader.Authorization] = "Basic " + creds;
+                using var wc = new WebClient();
+                var creds = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{instance.AdminUser}:{instance.AdminPassword}"));
+                wc.Headers[HttpRequestHeader.Authorization] = "Basic " + creds;
 
-                    var responseBytes = await wc.UploadValuesTaskAsync(instance.Url, new NameValueCollection
-                    {
-                        ["s"] = server.Name,
-                        ["action"] = action.AsString(EnumFormat.Description),
-                        ["b"] = p.Name
-                    });
-                    var response = Encoding.UTF8.GetString(responseBytes);
-                    return response.StartsWith("HTTP/1.0 303") || response.StartsWith("HTTP/1.1 303");
-                }
+                var responseBytes = await wc.UploadValuesTaskAsync(instance.Url, new NameValueCollection
+                {
+                    ["s"] = server.Name,
+                    ["action"] = action.AsString(EnumFormat.Description),
+                    ["b"] = p.Name
+                });
+                var response = Encoding.UTF8.GetString(responseBytes);
+                return response.StartsWith("HTTP/1.0 303") || response.StartsWith("HTTP/1.1 303");
             }
             catch (Exception e)
             {

--- a/src/Opserver.Core/Data/HAProxy/HAProxyInstance.cs
+++ b/src/Opserver.Core/Data/HAProxy/HAProxyInstance.cs
@@ -82,12 +82,10 @@ namespace Opserver.Data.HAProxy
                 req.Credentials = new NetworkCredential(User, Password);
                 if (QueryTimeoutMs.HasValue)
                     req.Timeout = QueryTimeoutMs.Value;
-                using (var resp = await req.GetResponseAsync())
-                using (var rs = resp.GetResponseStream())
-                {
-                    if (rs == null) return null;
-                    return await ParseHAProxyStats(rs);
-                }
+                using var resp = await req.GetResponseAsync();
+                using var rs = resp.GetResponseStream();
+                if (rs == null) return null;
+                return await ParseHAProxyStats(rs);
             }
         }
 

--- a/src/Opserver.Core/Data/HAProxy/HAProxyInstance.cs
+++ b/src/Opserver.Core/Data/HAProxy/HAProxyInstance.cs
@@ -65,13 +65,13 @@ namespace Opserver.Data.HAProxy
 
         private Cache<List<Proxy>> _proxies;
         public Cache<List<Proxy>> Proxies =>
-            _proxies ?? (_proxies = new Cache<List<Proxy>>(this, "HAProxy Fetch: " + Name,
+            _proxies ??= new Cache<List<Proxy>>(this, "HAProxy Fetch: " + Name,
                 cacheDuration: 10.Seconds(),
                 getData: FetchHAProxyStatsAsync,
                 addExceptionData: e => e.AddLoggedData("Server", Name)
                     .AddLoggedData("Url", Url)
                     .AddLoggedData("QueryTimeout", QueryTimeoutMs.ToString())
-            ));
+            );
 
         private async Task<List<Proxy>> FetchHAProxyStatsAsync()
         {

--- a/src/Opserver.Core/Data/HAProxy/Item.cs
+++ b/src/Opserver.Core/Data/HAProxy/Item.cs
@@ -22,7 +22,7 @@ namespace Opserver.Data.HAProxy
         private static readonly Regex _compactReplacer = new Regex(@"-\d+$", RegexOptions.Compiled);
         private string _compactServerName;
         public string CompactServerName =>
-            _compactServerName ?? (_compactServerName = _compactReplacer.Replace(ServerName, ""));
+            _compactServerName ??= _compactReplacer.Replace(ServerName, "");
 
         /// <summary>
         /// qcur: current queued requests
@@ -460,7 +460,7 @@ namespace Opserver.Data.HAProxy
             : ProxyName + " Status: " + ProxyServerStatus.AsString(EnumFormat.Description);
 
         private ProxyServerStatus? _proxyServerStatus;
-        public ProxyServerStatus ProxyServerStatus => _proxyServerStatus ?? (_proxyServerStatus = GetProxyServerStatus()).Value;
+        public ProxyServerStatus ProxyServerStatus => _proxyServerStatus ??= GetProxyServerStatus();
 
         private ProxyServerStatus GetProxyServerStatus()
         {

--- a/src/Opserver.Core/Data/HAProxy/Item.cs
+++ b/src/Opserver.Core/Data/HAProxy/Item.cs
@@ -389,22 +389,15 @@ namespace Opserver.Data.HAProxy
             return result;
         }
 
-        private static Item GetStatOfType(string typeNum)
-        {
-            switch ((StatusType)int.Parse(typeNum))
+        private static Item GetStatOfType(string typeNum) =>
+            ((StatusType)int.Parse(typeNum)) switch
             {
-                case StatusType.Frontend:
-                    return new Frontend();
-                case StatusType.Backend:
-                    return new Backend();
-                case StatusType.Server:
-                    return new Server();
-                case StatusType.Socket:
-                    return new Socket();
-                default:
-                    throw new ArgumentOutOfRangeException("Unrecognized StatusType " + typeNum);
-            }
-        }
+                StatusType.Frontend => new Frontend(),
+                StatusType.Backend => new Backend(),
+                StatusType.Server => new Server(),
+                StatusType.Socket => new Socket(),
+                _ => throw new ArgumentOutOfRangeException("Unrecognized StatusType " + typeNum),
+            };
 
         public bool IsFrontend => Type == StatusType.Frontend;
         public bool IsServer => Type == StatusType.Server;
@@ -471,27 +464,20 @@ namespace Opserver.Data.HAProxy
             if (_downGoingUp.IsMatch(Status))
                 return IsActive ? ProxyServerStatus.ActiveDownGoingUp : ProxyServerStatus.BackupDownGoingUp;
 
-            switch (Status)
+            return Status switch
             {
                 // Server is fully up
-                case "UP":
-                    return IsActive ? ProxyServerStatus.ActiveUp : ProxyServerStatus.BackupUp;
-                case "OPEN":
-                    return ProxyServerStatus.Open;
+                "UP" => IsActive ? ProxyServerStatus.ActiveUp : ProxyServerStatus.BackupUp,
+                "OPEN" => ProxyServerStatus.Open,
                 // Server is completely down
-                case "DOWN":
-                    return ProxyServerStatus.Down;
-                case "MAINT":
-                    return ProxyServerStatus.Maintenance;
-                case "DRAIN":
-                    return ProxyServerStatus.Drain;
+                "DOWN" => ProxyServerStatus.Down,
+                "MAINT" => ProxyServerStatus.Maintenance,
+                "DRAIN" => ProxyServerStatus.Drain,
                 // Server is not checked
-                case "no check":
-                    return ProxyServerStatus.NotChecked;
+                "no check" => ProxyServerStatus.NotChecked,
                 // We have no idea what happened to this poor server, someone go check on it?...or we're not a server
-                default:
-                    return ProxyServerStatus.None;
-            }
+                _ => ProxyServerStatus.None,
+            };
         }
     }
 }

--- a/src/Opserver.Core/Data/HAProxy/Proxy.cs
+++ b/src/Opserver.Core/Data/HAProxy/Proxy.cs
@@ -87,9 +87,9 @@ namespace Opserver.Data.HAProxy
 
         private string _niceName;
         public string NiceName =>
-            _niceName ?? (_niceName = Instance.Module.Settings.Aliases.TryGetValue(Name, out string result)
+            _niceName ??= Instance.Module.Settings.Aliases.TryGetValue(Name, out string result)
                           ? result
-                          : Name);
+                          : Name;
 
         public override string ToString() =>
             (Instance.Group != null ? Instance.Group.Name + ": " : "") + Instance.Name + ": " + Name;

--- a/src/Opserver.Core/Data/HAProxy/ServerStatus.cs
+++ b/src/Opserver.Core/Data/HAProxy/ServerStatus.cs
@@ -38,35 +38,22 @@ namespace Opserver.Data.HAProxy
 
     public static class ProxyServerStatusExtensions
     {
-        public static string ShortDescription(this ProxyServerStatus status)
-        {
-            switch (status)
+        public static string ShortDescription(this ProxyServerStatus status) =>
+            status switch
             {
-                case ProxyServerStatus.ActiveUp:
-                    return "Active";
-                case ProxyServerStatus.ActiveUpGoingDown:
-                    return "Active (Up -> Down)";
-                case ProxyServerStatus.ActiveDownGoingUp:
-                    return "Active (Down -> Up)";
-                case ProxyServerStatus.BackupUp:
-                    return "Backup";
-                case ProxyServerStatus.BackupUpGoingDown:
-                    return "Backup (Up -> Down)";
-                case ProxyServerStatus.BackupDownGoingUp:
-                    return "Backup (Down -> Up)";
-                case ProxyServerStatus.NotChecked:
-                    return "Not Checked";
-                case ProxyServerStatus.Down:
-                    return "Down";
-                case ProxyServerStatus.Maintenance:
-                    return "Maintenance";
-                case ProxyServerStatus.Open:
-                    return "Open";
+                ProxyServerStatus.ActiveUp => "Active",
+                ProxyServerStatus.ActiveUpGoingDown => "Active (Up -> Down)",
+                ProxyServerStatus.ActiveDownGoingUp => "Active (Down -> Up)",
+                ProxyServerStatus.BackupUp => "Backup",
+                ProxyServerStatus.BackupUpGoingDown => "Backup (Up -> Down)",
+                ProxyServerStatus.BackupDownGoingUp => "Backup (Down -> Up)",
+                ProxyServerStatus.NotChecked => "Not Checked",
+                ProxyServerStatus.Down => "Down",
+                ProxyServerStatus.Maintenance => "Maintenance",
+                ProxyServerStatus.Open => "Open",
                 //case ProxyServerStatus.None:
-                default:
-                    return "Unknown";
-            }
-        }
+                _ => "Unknown",
+            };
 
         public static bool IsBad(this ProxyServerStatus status)
         {

--- a/src/Opserver.Core/Data/IPNet.cs
+++ b/src/Opserver.Core/Data/IPNet.cs
@@ -26,10 +26,10 @@ namespace Opserver.Data
         private TinyIPAddress? _tinySubnet { get; set; }
 
         internal TinyIPAddress TIPAddress =>
-            (_tinyIPAddress ?? (_tinyIPAddress = TinyIPAddress.FromIPAddress(IPAddress))).Value;
+            (_tinyIPAddress ??= TinyIPAddress.FromIPAddress(IPAddress)).Value;
 
         internal TinyIPAddress TSubnet =>
-            (_tinySubnet ?? (_tinySubnet = TinyIPAddress.FromIPAddress(Subnet ?? IPAddress))).Value;
+            (_tinySubnet ??= TinyIPAddress.FromIPAddress(Subnet ?? IPAddress)).Value;
 
         public IPAddress FirstAddressInSubnet => TinyFirstAddressInSubnet.ToIPAddress();
         public IPAddress LastAddressInSubnet => TinyLastAddressInSubnet.ToIPAddress();

--- a/src/Opserver.Core/Data/IPNet.cs
+++ b/src/Opserver.Core/Data/IPNet.cs
@@ -136,15 +136,13 @@ namespace Opserver.Data
         public static IPAddress ToNetmask(AddressFamily addressFamily, int cidr) =>
             IPAddressFromCIDR(GetBitLength(addressFamily), cidr);
 
-        private static int GetBitLength(AddressFamily family)
-        {
-            switch (family)
+        private static int GetBitLength(AddressFamily family) =>
+            family switch
             {
-                case AddressFamily.InterNetwork: return 32;
-                case AddressFamily.InterNetworkV6: return 128;
-                default: throw new ArgumentOutOfRangeException(nameof(family), "You're probably from the future, they added another more IPs, fix me.");
-            }
-        }
+                AddressFamily.InterNetwork => 32,
+                AddressFamily.InterNetworkV6 => 128,
+                _ => throw new ArgumentOutOfRangeException(nameof(family), "You're probably from the future, they added another more IPs, fix me."),
+            };
 
         // This is a much faster version thanks to Marc Gravell
         private static IPAddress IPAddressFromCIDR(int bitLength, int cidr)

--- a/src/Opserver.Core/Data/Jira/JiraClient.cs
+++ b/src/Opserver.Core/Data/Jira/JiraClient.cs
@@ -160,7 +160,7 @@ namespace Opserver.Data.Jira
             {
                 return string.Empty;
             }
-            bool isHidden(string k) => DefaultHttpKeys.Contains(k);
+            static bool isHidden(string k) => DefaultHttpKeys.Contains(k);
             var allKeys = vars.AllKeys.Where(key => !HiddenHttpKeys.Contains(key) && vars[key].HasValue()).OrderBy(k => k);
 
             var sb = StringBuilderCache.Get();
@@ -263,7 +263,7 @@ namespace Opserver.Data.Jira
 
         public async Task<TResponse> GetAsync<TResponse>(string resource)
         {
-            client = client ?? new WebClient();
+            client ??= new WebClient();
             client.Headers.Add(HttpRequestHeader.Accept, "application/json");
             client.Encoding = Encoding.UTF8;
             var authz = GetBasicAuthzValue();
@@ -279,7 +279,7 @@ namespace Opserver.Data.Jira
 
         public async Task<TResponse> PostAsync<TResponse, TData>(string resource, TData data) where TResponse : class
         {
-            client = client ?? new WebClient();
+            client ??= new WebClient();
             client.Headers.Add(HttpRequestHeader.ContentType, "application/json");
             client.Encoding = Encoding.UTF8;
             var authz = GetBasicAuthzValue();

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Incidents.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Incidents.cs
@@ -99,23 +99,14 @@ namespace Opserver.Data.PagerDuty
 
         public Task<List<LogEntry>> GetLogsAsync() => Module.API.GetIncidentEntriesAsync(Id);
 
-        public MonitorStatus MonitorStatus
-        {
-            get
+        public MonitorStatus MonitorStatus =>
+            Status switch
             {
-                switch (Status)
-                {
-                    case IncidentStatus.triggered:
-                        return MonitorStatus.Critical;
-                    case IncidentStatus.acknowledged:
-                        return MonitorStatus.Warning;
-                    case IncidentStatus.resolved:
-                        return MonitorStatus.Good;
-                    default:
-                        return MonitorStatus.Unknown;
-                }
-            }
-        }
+                IncidentStatus.triggered => MonitorStatus.Critical,
+                IncidentStatus.acknowledged => MonitorStatus.Warning,
+                IncidentStatus.resolved => MonitorStatus.Good,
+                _ => MonitorStatus.Unknown,
+            };
 
         public string MonitorStatusReason => "Status is " + Status.AsString(EnumFormat.Description);
     }

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Incidents.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Incidents.cs
@@ -13,7 +13,7 @@ namespace Opserver.Data.PagerDuty
         private Cache<List<Incident>> _incidents;
 
         public Cache<List<Incident>> Incidents =>
-            _incidents ?? (_incidents = GetPagerDutyCache(10.Minutes(), () =>
+            _incidents ??= GetPagerDutyCache(10.Minutes(), () =>
             {
                 string since = DateTime.UtcNow.AddDays(-Settings.DaysToCache).ToString("yyyy-MM-dd"),
                        until = DateTime.UtcNow.AddDays(1).ToString("yyyy-MM-dd");
@@ -29,7 +29,7 @@ namespace Opserver.Data.PagerDuty
                     }
                     return results;
                 });
-            }));
+            });
     }
 
     public class IncidentResponse

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.OnCall.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.OnCall.cs
@@ -117,22 +117,15 @@ namespace Opserver.Data.PagerDuty
         [DataMember(Name = "escalation_level")]
         public int? EscalationLevel { get; set; }
 
-        public static string GetEscalationLevelDescription(int? level)
-        {
-            switch (level)
+        public static string GetEscalationLevelDescription(int? level) =>
+            level switch
             {
-                case 1:
-                    return "Primary";
-                case 2:
-                    return "Secondary";
-                case 3:
-                    return "Third";
-                case null:
-                    return "Unknown";
-                default:
-                    return level.ToString() + "th";
-            }
-        }
+                1 => "Primary",
+                2 => "Secondary",
+                3 => "Third",
+                null => "Unknown",
+                _ => level.ToString() + "th",
+            };
 
         private string _emailusername;
         public string EmailUserName => _emailusername ??= Email.HasValue() ? Email.Split(StringSplits.AtSign)[0] : "";
@@ -257,17 +250,13 @@ namespace Opserver.Data.PagerDuty
             {
                 if (EscalationLevel.HasValue)
                 {
-                    switch (EscalationLevel.Value)
+                    return EscalationLevel.Value switch
                     {
-                        case 1:
-                            return "Primary";
-                        case 2:
-                            return "Secondary";
-                        case 3:
-                            return "Third";
-                        default:
-                            return EscalationLevel.Value + "th";
-                    }
+                        1 => "Primary",
+                        2 => "Secondary",
+                        3 => "Third",
+                        _ => EscalationLevel.Value + "th",
+                    };
                 }
 
                 return "unknown";

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.OnCall.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.OnCall.cs
@@ -18,12 +18,12 @@ namespace Opserver.Data.PagerDuty
             OnCallInfo.Data?.FirstOrDefault(p => p.EscalationLevel == 2)?.AssignedUser;
 
         private Cache<List<OnCall>> _oncallinfo;
-        public Cache<List<OnCall>> OnCallInfo => _oncallinfo ?? (_oncallinfo = new Cache<List<OnCall>>(
+        public Cache<List<OnCall>> OnCallInfo => _oncallinfo ??= new Cache<List<OnCall>>(
             this,
             "On Call information for Pagerduty",
             5.Minutes(),
             getData: GetOnCallUsers,
-            logExceptions: true));
+            logExceptions: true);
 
         public List<OnCall> GetOnCall(int? maxPerSchedule = null) =>
             OnCallInfo.SafeData(true).Where(c => c.EscalationLevel.GetValueOrDefault(int.MaxValue) <= (maxPerSchedule ?? Settings.OnCallToShow)).ToList();
@@ -135,7 +135,7 @@ namespace Opserver.Data.PagerDuty
         }
 
         private string _emailusername;
-        public string EmailUserName => _emailusername ?? (_emailusername = Email.HasValue() ? Email.Split(StringSplits.AtSign)[0] : "");
+        public string EmailUserName => _emailusername ??= Email.HasValue() ? Email.Split(StringSplits.AtSign)[0] : "";
     }
 
     public class PagerDutyContactMethod

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Schedules.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.Schedules.cs
@@ -26,10 +26,10 @@ namespace Opserver.Data.PagerDuty
         private Cache<List<PagerDutySchedule>> _schedules;
 
         public Cache<List<PagerDutySchedule>> AllSchedules =>
-            _schedules ?? (_schedules = GetPagerDutyCache(10.Minutes(),
+            _schedules ??= GetPagerDutyCache(10.Minutes(),
                 () => GetFromPagerDutyAsync("schedules",
                         response => JSON.Deserialize<PagerDutyScheduleResponse>(response, JilOptions).Schedules)
-            ));
+            );
 
         private Cache<List<PagerDutyScheduleOverride>> _primaryScheduleOverrides;
         public Cache<List<PagerDutyScheduleOverride>> PrimaryScheduleOverrides
@@ -38,7 +38,7 @@ namespace Opserver.Data.PagerDuty
             {
                 var schedule = PrimarySchedule;
                 if (schedule == null) return null;
-                return _primaryScheduleOverrides ?? (_primaryScheduleOverrides = GetPagerDutyCache(10.Minutes(), () => GetOverridesAsync(PrimarySchedule)));
+                return _primaryScheduleOverrides ??= GetPagerDutyCache(10.Minutes(), () => GetOverridesAsync(PrimarySchedule));
             }
         }
 

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.cs
@@ -158,8 +158,8 @@ namespace Opserver.Data.PagerDuty
 
         private Cache<List<PagerDutyPerson>> _allusers;
         public Cache<List<PagerDutyPerson>> AllUsers =>
-            _allusers ?? (_allusers = GetPagerDutyCache(60.Minutes(),
-                    () => GetFromPagerDutyAsync("users?include[]=contact_methods", r => JSON.Deserialize<PagerDutyUserResponse>(r, JilOptions).Users))
+            _allusers ??= GetPagerDutyCache(60.Minutes(),
+                    () => GetFromPagerDutyAsync("users?include[]=contact_methods", r => JSON.Deserialize<PagerDutyUserResponse>(r, JilOptions).Users)
             );
     }
 }

--- a/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.cs
+++ b/src/Opserver.Core/Data/PagerDuty/PagerDutyAPI.cs
@@ -118,27 +118,19 @@ namespace Opserver.Data.PagerDuty
                 try
                 {
                     var resp = await req.GetResponseAsync();
-                    using (var rs = resp.GetResponseStream())
-                    {
-                        if (rs == null) return getFromJson(null);
-                        using (var sr = new StreamReader(rs))
-                        {
-                            return getFromJson(sr.ReadToEnd());
-                        }
-                    }
+                    using var rs = resp.GetResponseStream();
+                    if (rs == null) return getFromJson(null);
+                    using var sr = new StreamReader(rs);
+                    return getFromJson(sr.ReadToEnd());
                 }
                 catch (WebException e)
                 {
                     try
                     {
-                        using (var ers = e.Response.GetResponseStream())
-                        {
-                            if (ers == null) return getFromJson(null);
-                            using (var er = new StreamReader(ers))
-                            {
-                                e.AddLoggedData("API Response JSON", er.ReadToEnd());
-                            }
-                        }
+                        using var ers = e.Response.GetResponseStream();
+                        if (ers == null) return getFromJson(null);
+                        using var er = new StreamReader(ers);
+                        e.AddLoggedData("API Response JSON", er.ReadToEnd());
                     }
                     catch (Exception rex)
                     {

--- a/src/Opserver.Core/Data/PollingService.cs
+++ b/src/Opserver.Core/Data/PollingService.cs
@@ -26,7 +26,7 @@ namespace Opserver.Data
             _cancellationToken = cancellationToken;
             _logger.LogInformation("Polling service is starting.");
             _startTime = DateTime.UtcNow;
-            _globalPollingThread = _globalPollingThread ?? new Thread(MonitorPollingLoop)
+            _globalPollingThread ??= new Thread(MonitorPollingLoop)
             {
                 Name = "GlobalPolling",
                 Priority = ThreadPriority.Lowest,

--- a/src/Opserver.Core/Data/Redis/RedisAnalyzer.Memory.cs
+++ b/src/Opserver.Core/Data/Redis/RedisAnalyzer.Memory.cs
@@ -60,23 +60,21 @@ namespace Opserver.Data.Redis
                     { connectionInfo.Host, connectionInfo.Port }
                 }
             };
-            using (var muxer = ConnectionMultiplexer.Connect(config))
+            using var muxer = ConnectionMultiplexer.Connect(config);
+            var ma = new RedisMemoryAnalysis(this, connectionInfo, database);
+            if (ma.ErrorMessage.HasValue())
             {
-                var ma = new RedisMemoryAnalysis(this, connectionInfo, database);
-                if (ma.ErrorMessage.HasValue())
-                {
-                    return ma;
-                }
-                // Prep the match dictionary
-                foreach (var km in KeyMatchers)
-                {
-                    ma.KeyStats[km] = new KeyStats();
-                }
-
-                ma.Analyze(muxer);
-
                 return ma;
             }
+            // Prep the match dictionary
+            foreach (var km in KeyMatchers)
+            {
+                ma.KeyStats[km] = new KeyStats();
+            }
+
+            ma.Analyze(muxer);
+
+            return ma;
         }
     }
 

--- a/src/Opserver.Core/Data/Redis/RedisInfo.Parsing.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInfo.Parsing.cs
@@ -53,7 +53,7 @@ namespace Opserver.Data.Redis
                     else
                     {
                         currentSection = new RedisInfoSection { Name = sectionName, IsUnrecognized = true };
-                        info.UnrecognizedSections = info.UnrecognizedSections ?? new List<RedisInfoSection>();
+                        info.UnrecognizedSections ??= new List<RedisInfoSection>();
                         info.UnrecognizedSections.Add(currentSection);
                     }
                     continue;

--- a/src/Opserver.Core/Data/Redis/RedisInfo.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInfo.cs
@@ -158,7 +158,7 @@ namespace Opserver.Data.Redis
             public long Offset { get; internal set; }
 
             private IPAddress _ipAddress;
-            public IPAddress IPAddress => _ipAddress ?? (_ipAddress = IPAddress.Parse(IP));
+            public IPAddress IPAddress => _ipAddress ??= IPAddress.Parse(IP);
         }
 
         public ClientInfo Clients { get; internal set; } = new ClientInfo();
@@ -178,7 +178,7 @@ namespace Opserver.Data.Redis
         public class ServerInfo : RedisInfoSection
         {
             private Version _version;
-            public Version Version => _version ?? (_version = VersionNumber.HasValue() ? Version.Parse(VersionNumber) : new Version());
+            public Version Version => _version ??= VersionNumber.HasValue() ? Version.Parse(VersionNumber) : new Version();
 
             [RedisInfoProperty("redis_version")]
             public string VersionNumber { get; internal set; }

--- a/src/Opserver.Core/Data/Redis/RedisInfo.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInfo.cs
@@ -42,18 +42,13 @@ namespace Opserver.Data.Redis
         public ReplicationInfo Replication { get; internal set; } = new ReplicationInfo();
         public class ReplicationInfo : RedisInfoSection
         {
-            public RedisInstanceRole RedisInstanceRole
-            {
-                get
+            public RedisInstanceRole RedisInstanceRole =>
+                Role switch
                 {
-                    switch (Role)
-                    {
-                        case "master": return RedisInstanceRole.Master;
-                        case "slave": return RedisInstanceRole.Slave;
-                        default: return RedisInstanceRole.Unknown;
-                    }
-                }
-            }
+                    "master" => RedisInstanceRole.Master,
+                    "slave" => RedisInstanceRole.Slave,
+                    _ => RedisInstanceRole.Unknown,
+                };
 
             [RedisInfoProperty("role")]
             public string Role { get; internal set; }

--- a/src/Opserver.Core/Data/Redis/RedisInstance.Actions.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.Actions.cs
@@ -29,11 +29,9 @@ namespace Opserver.Data.Redis
         /// </summary>
         public string PromoteToMaster()
         {
-            using (var log = new StringWriter())
-            {
-                _connection.GetSingleServer().MakeMaster(ReplicationChangeOptions.Broadcast, log);
-                return log.ToString();
-            }
+            using var log = new StringWriter();
+            _connection.GetSingleServer().MakeMaster(ReplicationChangeOptions.Broadcast, log);
+            return log.ToString();
         }
 
         /// <summary>

--- a/src/Opserver.Core/Data/Redis/RedisInstance.Clients.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.Clients.cs
@@ -9,13 +9,13 @@ namespace Opserver.Data.Redis
     {
         private Cache<List<ClientInfo>> _clients;
         public Cache<List<ClientInfo>> Clients =>
-            _clients ?? (_clients = GetRedisCache(60.Seconds(), async () =>
+            _clients ??= GetRedisCache(60.Seconds(), async () =>
             {
                 using (MiniProfiler.Current.CustomTiming("redis", "CLIENT LIST"))
                 {
                     var result = await Connection.GetSingleServer().ClientListAsync();
                     return result.ToList();
                 }
-            }));
+            });
     }
 }

--- a/src/Opserver.Core/Data/Redis/RedisInstance.Config.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.Config.cs
@@ -10,13 +10,13 @@ namespace Opserver.Data.Redis
         private Cache<Dictionary<string, string>> _config;
 
         public Cache<Dictionary<string, string>> Config =>
-            _config ?? (_config = GetRedisCache(2.Minutes(), async () =>
+            _config ??= GetRedisCache(2.Minutes(), async () =>
             {
                 using (MiniProfiler.Current.CustomTiming("redis", "CONFIG"))
                 {
                     return (await Connection.GetSingleServer().ConfigGetAsync("*")).ToDictionary(x => x.Key, x => x.Value);
                 }
-            }));
+            });
 
         /// <summary>
         /// Sets a config value without needing a restart

--- a/src/Opserver.Core/Data/Redis/RedisInstance.Info.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.Info.cs
@@ -28,7 +28,7 @@ namespace Opserver.Data.Redis
 
         private Cache<RedisInfo> _info;
         public Cache<RedisInfo> Info =>
-            _info ?? (_info = GetRedisCache(10.Seconds(), async () =>
+            _info ??= GetRedisCache(10.Seconds(), async () =>
             {
                 var server = Connection.GetSingleServer();
                 string infoStr;
@@ -40,7 +40,7 @@ namespace Opserver.Data.Redis
                 var ri = RedisInfo.FromInfoString(infoStr);
                 if (ri != null) Replication = ri.Replication;
                 return ri;
-            }));
+            });
 
         public RedisInfo.RedisInstanceRole Role
         {

--- a/src/Opserver.Core/Data/Redis/RedisInstance.Info.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.Info.cs
@@ -57,21 +57,13 @@ namespace Opserver.Data.Redis
             }
         }
 
-        public string RoleDescription
-        {
-            get
+        public string RoleDescription =>
+            Role switch
             {
-                switch (Role)
-                {
-                    case RedisInfo.RedisInstanceRole.Master:
-                        return "Master";
-                    case RedisInfo.RedisInstanceRole.Slave:
-                        return "Slave";
-                    default:
-                        return "Unknown";
-                }
-            }
-        }
+                RedisInfo.RedisInstanceRole.Master => "Master",
+                RedisInfo.RedisInstanceRole.Slave => "Slave",
+                _ => "Unknown",
+            };
 
         public bool IsMaster => Role == RedisInfo.RedisInstanceRole.Master;
         public bool IsSlave => Role == RedisInfo.RedisInstanceRole.Slave;

--- a/src/Opserver.Core/Data/Redis/RedisInstance.SlowLog.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.SlowLog.cs
@@ -25,24 +25,24 @@ namespace Opserver.Data.Redis
 
         private Cache<List<CommandTrace>> _slowLog;
         public Cache<List<CommandTrace>> SlowLog =>
-            _slowLog ?? (_slowLog = GetRedisCache(60.Seconds(), async () =>
+            _slowLog ??= GetRedisCache(60.Seconds(), async () =>
             {
                 //TODO: Remove when StackExchange.Redis gets profiling
                 using (MiniProfiler.Current.CustomTiming("redis", "slowlog get " + SlowLogCountToFetch.ToString()))
                 {
                     return (await Connection.GetSingleServer().SlowlogGetAsync(SlowLogCountToFetch)).ToList();
                 }
-            }));
+            });
 
         private Cache<string> _tieBreaker;
         public Cache<string> Tiebreaker =>
-            _tieBreaker ?? (_tieBreaker = GetRedisCache(10.Seconds(), async () =>
+            _tieBreaker ??= GetRedisCache(10.Seconds(), async () =>
             {
                 using (MiniProfiler.Current.CustomTiming("redis", "tiebreaker fetch"))
                 {
                     return await GetSERedisTiebreakerAsync(Connection);
                 }
-            }));
+            });
 
         /// <summary>
         /// Sets the slow log threshold in milliseconds, note: 0 logs EVERY command, null or negative disables logging.

--- a/src/Opserver.Core/Data/Redis/RedisInstance.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstance.cs
@@ -28,7 +28,7 @@ namespace Opserver.Data.Redis
         public bool UseSsl => ConnectionInfo.Settings.UseSSL;
 
         private string _hostAndPort;
-        public string HostAndPort => _hostAndPort ?? (_hostAndPort = Host + ":" + Port.ToString());
+        public string HostAndPort => _hostAndPort ??= Host + ":" + Port.ToString();
 
         // Redis is spanish for WE LOVE DANGER, I think.
         protected override TimeSpan BackoffDuration => TimeSpan.FromSeconds(5);
@@ -43,7 +43,7 @@ namespace Opserver.Data.Redis
             {
                 if (_connection?.IsConnected != true)
                 {
-                    _connection = _connection ?? GetConnection(allowAdmin: true);
+                    _connection ??= GetConnection(allowAdmin: true);
                     if (!_connection.IsConnected)
                     {
                         _connection.Configure();

--- a/src/Opserver.Core/Data/Redis/RedisInstanceOperation.cs
+++ b/src/Opserver.Core/Data/Redis/RedisInstanceOperation.cs
@@ -43,18 +43,13 @@ namespace Opserver.Data.Redis
             throw new ArgumentOutOfRangeException(nameof(s), $"Invalid op string provided: '{s}'");
         }
 
-        public override string ToString()
-        {
-            switch (Command)
+        public override string ToString() =>
+            Command switch
             {
-                case InstanceCommandType.MakeMaster:
-                    return $"{InstanceCommandType.MakeMaster}|{Instance.UniqueKey}";
-                case InstanceCommandType.SlaveTo:
-                    return $"{InstanceCommandType.SlaveTo}|{Instance.UniqueKey}|{NewMaster.UniqueKey}";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(InstanceCommandType));
-            }
-        }
+                InstanceCommandType.MakeMaster => $"{InstanceCommandType.MakeMaster}|{Instance.UniqueKey}",
+                InstanceCommandType.SlaveTo => $"{InstanceCommandType.SlaveTo}|{Instance.UniqueKey}|{NewMaster.UniqueKey}",
+                _ => throw new ArgumentOutOfRangeException(nameof(InstanceCommandType)),
+            };
 
         public static RedisInstanceOperation MakeMaster(RedisInstance instance) =>
             new RedisInstanceOperation

--- a/src/Opserver.Core/Data/SQL/SQLInstance.ActiveOperations.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.ActiveOperations.cs
@@ -123,10 +123,8 @@ namespace Opserver.Data.SQL
             {
                 if (QueryPlan == null) return new ShowPlanXML();
                 var s = new XmlSerializer(typeof(ShowPlanXML));
-                using (var r = new StringReader(QueryPlan))
-                {
-                    return (ShowPlanXML)s.Deserialize(r);
-                }
+                using var r = new StringReader(QueryPlan);
+                return (ShowPlanXML)s.Deserialize(r);
             }
 
             public ActiveOperation(WhoIsActiveRow row)

--- a/src/Opserver.Core/Data/SQL/SQLInstance.CPUHistory.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.CPUHistory.cs
@@ -10,13 +10,13 @@ namespace Opserver.Data.SQL
         private Cache<List<ResourceEvent>> _resourceHistory;
 
         public Cache<List<ResourceEvent>> ResourceHistory =>
-            _resourceHistory ?? (_resourceHistory = GetSqlCache(nameof(ResourceHistory), async conn =>
+            _resourceHistory ??= GetSqlCache(nameof(ResourceHistory), async conn =>
             {
                 var sql = GetFetchSQL<ResourceEvent>();
                 var result = await conn.QueryAsync<ResourceEvent>(sql);
                 CurrentCPUPercent = result.Count > 0 ? result.Last().ProcessUtilization : (int?) null;
                 return result;
-            }));
+            });
 
         public int? CurrentCPUPercent { get; set; }
 
@@ -25,7 +25,7 @@ namespace Opserver.Data.SQL
             Version IMinVersioned.MinVersion => SQLServerVersions.SQL2005.RTM;
 
             private long? _dateEpoch;
-            public long DateEpoch => _dateEpoch ?? (_dateEpoch = EventTime.ToEpochTime()).Value;
+            public long DateEpoch => _dateEpoch ??= EventTime.ToEpochTime();
             public DateTime EventTime { get; internal set; }
             public int ProcessUtilization { get; internal set; }
             public int MemoryUtilization { get; internal set; }

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Configuration.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Configuration.cs
@@ -8,7 +8,7 @@ namespace Opserver.Data.SQL
         private Cache<List<SQLConfigurationOption>> _configuration;
 
         public Cache<List<SQLConfigurationOption>> Configuration =>
-            _configuration ?? (_configuration = GetSqlCache(nameof(Configuration),
+            _configuration ??= GetSqlCache(nameof(Configuration),
                 async conn =>
                 {
                     var result = await conn.QueryAsync<SQLConfigurationOption>(GetFetchSQL<SQLConfigurationOption>());
@@ -18,10 +18,10 @@ namespace Opserver.Data.SQL
                             r.Default = defaultVal;
                     }
                     return result;
-                }));
+                });
 
         private Dictionary<string, int> _configurationDefaults;
-        public Dictionary<string, int> ConfigurationDefaults => _configurationDefaults ?? (_configurationDefaults = SQLConfigurationOption.GetDefaults(this));
+        public Dictionary<string, int> ConfigurationDefaults => _configurationDefaults ??= SQLConfigurationOption.GetDefaults(this);
 
         public class SQLConfigurationOption : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Connections.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Connections.cs
@@ -7,10 +7,10 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<SQLConnectionSummaryInfo>> _connectionsSummary;
-        public Cache<List<SQLConnectionSummaryInfo>> ConnectionsSummary => _connectionsSummary ?? (_connectionsSummary = SqlCacheList<SQLConnectionSummaryInfo>(30.Seconds()));
+        public Cache<List<SQLConnectionSummaryInfo>> ConnectionsSummary => _connectionsSummary ??= SqlCacheList<SQLConnectionSummaryInfo>(30.Seconds());
 
         private Cache<List<SQLConnectionInfo>> _connections;
-        public Cache<List<SQLConnectionInfo>> Connections => _connections ?? (_connections = SqlCacheList<SQLConnectionInfo>(RefreshInterval));
+        public Cache<List<SQLConnectionInfo>> Connections => _connections ??= SqlCacheList<SQLConnectionInfo>(RefreshInterval);
 
         public class SQLConnectionSummaryInfo : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -152,13 +152,11 @@ namespace Opserver.Data.SQL
                     if (IsReadOnly)
                         return Name + " database is read-only";
 
-                    switch (State)
+                    return State switch
                     {
-                        case DatabaseStates.Online:
-                            return null;
-                        default:
-                            return Name + " database is " + State.AsString(EnumFormat.Description);
-                    }
+                        DatabaseStates.Online => null,
+                        _ => Name + " database is " + State.AsString(EnumFormat.Description),
+                    };
                 }
             }
 
@@ -485,28 +483,18 @@ Select p.object_id,
             public char? RestoreType { get; internal set; }
             public string RestoreTypeDescription => GetTypeDescription(RestoreType);
 
-            public static string GetTypeDescription(char? type)
-            {
-                switch (type)
+            public static string GetTypeDescription(char? type) =>
+                type switch
                 {
-                    case 'D':
-                        return "Database";
-                    case 'F':
-                        return "File";
-                    case 'G':
-                        return "Filegroup";
-                    case 'I':
-                        return "Differential";
-                    case 'L':
-                        return "Log";
-                    case 'V':
-                        return "Verify Only";
-                    case null:
-                        return "";
-                    default:
-                        return "Unknown";
-                }
-            }
+                    'D' => "Database",
+                    'F' => "File",
+                    'G' => "Filegroup",
+                    'I' => "Differential",
+                    'L' => "Log",
+                    'V' => "Verify Only",
+                    null => "",
+                    _ => "Unknown",
+                };
 
             Version IMinVersioned.MinVersion =>  SQLServerVersions.SQL2008.SP1;
             public string GetFetchSQL(Version v)
@@ -541,30 +529,19 @@ Select r.restore_date RestoreFinishDate,
             public string LogicalDeviceName { get; internal set; }
             public string PhysicalDeviceName { get; internal set; }
 
-            public static string GetTypeDescription(char? type)
-            {
-                switch (type)
+            public static string GetTypeDescription(char? type) =>
+                type switch
                 {
-                    case 'D':
-                        return "Full";
-                    case 'I':
-                        return "Differential (DB)";
-                    case 'L':
-                        return "Log";
-                    case 'F':
-                        return "File/Filegroup";
-                    case 'G':
-                        return "Differential (File)";
-                    case 'P':
-                        return "Partial";
-                    case 'Q':
-                        return "Differential (Partial)";
-                    case null:
-                        return "";
-                    default:
-                        return "Unknown";
-                }
-            }
+                    'D' => "Full",
+                    'I' => "Differential (DB)",
+                    'L' => "Log",
+                    'F' => "File/Filegroup",
+                    'G' => "Differential (File)",
+                    'P' => "Partial",
+                    'Q' => "Differential (Partial)",
+                    null => "",
+                    _ => "Unknown",
+                };
 
             internal const string FetchSQL = @"
 Select Top 100
@@ -640,23 +617,14 @@ Select Top 100
                 }
             }
 
-            public string MaxSizeDescription
-            {
-                get
+            public string MaxSizeDescription =>
+                FileMaxSizePages switch
                 {
-                    switch (FileMaxSizePages)
-                    {
-                        case 0:
-                            return "At Max - No Growth";
-                        case -1:
-                            return "No Limit - Disk Capacity";
-                        case 268435456:
-                            return "2 TB";
-                        default:
-                            return (FileMaxSizePages*8*1024).ToHumanReadableSize();
-                    }
-                }
-            }
+                    0 => "At Max - No Growth",
+                    -1 => "No Limit - Disk Capacity",
+                    268435456 => "2 TB",
+                    _ => (FileMaxSizePages * 8 * 1024).ToHumanReadableSize(),
+                };
 
             public string GetFetchSQL(Version v) => @"
 Select mf.database_id DatabaseId,
@@ -696,22 +664,15 @@ Select mf.database_id DatabaseId,
             public bool IsDefault { get; internal set; }
             public bool IsSystem { get; internal set; }
 
-            public static string GetTypeDescription(string type)
-            {
-                switch (type)
+            public static string GetTypeDescription(string type) =>
+                type switch
                 {
-                    case "FG":
-                        return "Filegroup";
-                    case "PS":
-                        return "Partition Scheme";
-                    case "FD":
-                        return "FILESTREAM";
-                    case null:
-                        return "";
-                    default:
-                        return "Unknown";
-                }
-            }
+                    "FG" => "Filegroup",
+                    "PS" => "Partition Scheme",
+                    "FD" => "FILESTREAM",
+                    null => "",
+                    _ => "Unknown",
+                };
 
             public string GetFetchSQL(Version v) => @"
 Select data_space_id Id,
@@ -1046,21 +1007,13 @@ Order By 1, 2, 3";
             public long ReservedSpaceKB { get; internal set; }
             public int IndexCount { get; internal set; }
 
-            public string RangeValueString
-            {
-                get
+            public string RangeValueString =>
+                RangeValue switch
                 {
-                    switch (RangeValue)
-                    {
-                        case null:
-                            return string.Empty;
-                        case DateTime date:
-                            return date.ToString(date.TimeOfDay.Ticks == 0 ? "yyyy-MM-dd" : "u");
-                        default:
-                            return RangeValue.ToString();
-                    }
-                }
-            }
+                    null => string.Empty,
+                    DateTime date => date.ToString(date.TimeOfDay.Ticks == 0 ? "yyyy-MM-dd" : "u"),
+                    _ => RangeValue.ToString(),
+                };
 
             public string GetFetchSQL(Version v) => @"
   Select s.name SchemaName,

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Databases.cs
@@ -12,7 +12,7 @@ namespace Opserver.Data.SQL
         private Cache<List<Database>> _databases;
 
         public Cache<List<Database>> Databases =>
-            _databases ?? (_databases = GetSqlCache(nameof(Databases),
+            _databases ??= GetSqlCache(nameof(Databases),
                 async conn =>
                 {
                     var sql = QueryLookup.GetOrAdd(Tuple.Create(nameof(Databases), Version), k =>
@@ -45,7 +45,7 @@ namespace Opserver.Data.SQL
                     }
                     return dbs;
                 },
-                cacheDuration: 5.Minutes()));
+                cacheDuration: 5.Minutes());
 
         public LightweightCache<List<DatabaseFile>> GetFileInfo(string databaseName) =>
             DatabaseFetch<DatabaseFile>(databaseName);
@@ -164,7 +164,7 @@ namespace Opserver.Data.SQL
 
             private bool? _isSystemDatabase;
             public int Id { get; internal set; }
-            public bool IsSystemDatabase => (_isSystemDatabase ?? (_isSystemDatabase = SystemDatabaseNames.Contains(Name))).Value;
+            public bool IsSystemDatabase => _isSystemDatabase ??= SystemDatabaseNames.Contains(Name);
             public string Name { get; internal set; }
             public DatabaseStates State { get; internal set; }
             public CompatabilityLevels CompatibilityLevel { get; internal set; }
@@ -598,7 +598,7 @@ Select Top 100
             Version IMinVersioned.MinVersion => SQLServerVersions.SQL2005.RTM;
 
             private string _volumeMountPoint;
-            public string VolumeMountPoint => _volumeMountPoint ?? (_volumeMountPoint = PhysicalName?.Split(StringSplits.Colon)[0]);
+            public string VolumeMountPoint => _volumeMountPoint ??= PhysicalName?.Split(StringSplits.Colon)[0];
             public int DatabaseId { get; internal set; }
             public string DatabaseName { get; internal set; }
             public int FileId { get; internal set; }
@@ -625,7 +625,7 @@ Select Top 100
             private static readonly Regex _shortPathRegex = new Regex(@"C:\\Program Files\\Microsoft SQL Server\\MSSQL\d+.MSSQLSERVER\\MSSQL\\DATA", RegexOptions.Compiled);
             private string _shortPhysicalName;
             public string ShortPhysicalName =>
-                    _shortPhysicalName ?? (_shortPhysicalName = _shortPathRegex.Replace(PhysicalName ?? "", @"C:\Program...MSSQLSERVER\MSSQL\DATA"));
+                    _shortPhysicalName ??= _shortPathRegex.Replace(PhysicalName ?? "", @"C:\Program...MSSQLSERVER\MSSQL\DATA");
 
             public string GrowthDescription
             {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Features.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Features.cs
@@ -5,7 +5,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<SQLServerFeatures> _serverFeatures;
-        public Cache<SQLServerFeatures> ServerFeatures => _serverFeatures ?? (_serverFeatures = SqlCacheSingle<SQLServerFeatures>(60.Minutes()));
+        public Cache<SQLServerFeatures> ServerFeatures => _serverFeatures ??= SqlCacheSingle<SQLServerFeatures>(60.Minutes());
 
         public class SQLServerFeatures : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Jobs.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Jobs.cs
@@ -11,7 +11,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<SQLJobInfo>> _jobSummary;
-        public Cache<List<SQLJobInfo>> JobSummary => _jobSummary ?? (_jobSummary = SqlCacheList<SQLJobInfo>(2.Minutes()));
+        public Cache<List<SQLJobInfo>> JobSummary => _jobSummary ??= SqlCacheList<SQLJobInfo>(2.Minutes());
 
         /// <summary>
         /// Enables or disables a SQL agent job

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Jobs.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Jobs.cs
@@ -45,12 +45,10 @@ namespace Opserver.Data.SQL
         {
             try
             {
-                using (var conn = await GetConnectionAsync())
-                {
-                    await action(conn);
-                    await JobSummary.PollAsync(true);
-                    return true;
-                }
+                using var conn = await GetConnectionAsync();
+                await action(conn);
+                await JobSummary.PollAsync(true);
+                return true;
             }
             catch (Exception e)
             {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Memory.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Memory.cs
@@ -15,95 +15,89 @@ namespace Opserver.Data.SQL
             public string ClerkType { get; internal set; }
             public long UsedBytes { get; internal set; }
             public decimal UsedPercent { get; internal set; }
-            public string Name
-            {
-                get
+            public string Name =>
+                ClerkType switch
                 {
-                    switch (ClerkType)
-                    {
-                        case "CACHESTORE_BROKERDSH": return "Service Broker Dialog Security Header Cache";
-                        case "CACHESTORE_BROKERKEK": return "Service Broker Key Exchange Key Cache";
-                        case "CACHESTORE_BROKERREADONLY": return "Service Broker (Read-Only)";
-                        case "CACHESTORE_BROKERRSB": return "Service Broker Null Remote Service Binding Cache";
-                        case "CACHESTORE_BROKERTBLACS": return "Broker dormant rowsets";
-                        case "CACHESTORE_BROKERTO": return "Service Broker Transmission Object Cache";
-                        case "CACHESTORE_BROKERUSERCERTLOOKUP": return "Service Broker user certificates lookup result cache";
-                        case "CACHESTORE_CLRPROC": return "CLR Procedure Cache";
-                        case "CACHESTORE_CLRUDTINFO": return "CLR UDT Info";
-                        case "CACHESTORE_COLUMNSTOREOBJECTPOOL": return "Column Store Object Pool";
-                        case "CACHESTORE_CONVPRI": return "Conversation Priority Cache";
-                        case "CACHESTORE_EVENTS": return "Event Notification Cache";
-                        case "CACHESTORE_FULLTEXTSTOPLIST": return "Full Text Stoplist Cache";
-                        case "CACHESTORE_NOTIF": return "Notification Store";
-                        case "CACHESTORE_OBJCP": return "Object Plans";
-                        case "CACHESTORE_PHDR": return "Bound Trees";
-                        case "CACHESTORE_SEARCHPROPERTYLIST": return "Search Property List Cache";
-                        case "CACHESTORE_SEHOBTCOLUMNATTRIBUTE": return "SE Shared Column Metadata Cache";
-                        case "CACHESTORE_SQLCP": return "SQL Plans";
-                        case "CACHESTORE_STACKFRAMES": return "SOS_StackFramesStore";
-                        case "CACHESTORE_SYSTEMROWSET": return "System Rowset Store";
-                        case "CACHESTORE_TEMPTABLES": return "Temporary Tables & Table Variables";
-                        case "CACHESTORE_VIEWDEFINITIONS": return "View Definition Cache";
-                        case "CACHESTORE_XML_SELECTIVE_DG": return "XML DB Cache (Selective)";
-                        case "CACHESTORE_XMLDBATTRIBUTE": return "XML DB Cache (Attribute)";
-                        case "CACHESTORE_XMLDBELEMENT": return "XML DB Cache (Element)";
-                        case "CACHESTORE_XMLDBTYPE": return "XML DB Cache (Type)";
-                        case "CACHESTORE_XPROC": return "Extended Stored Procedures";
-                        case "MEMORYCLERK_BHF": return "Best Hugging Friend (According to Brent Ozar)";
-                        case "MEMORYCLERK_FILETABLE": return "Memory Clerk (File Table)";
-                        case "MEMORYCLERK_FSCHUNKER": return "Memory Clerk (FS Chunker)";
-                        case "MEMORYCLERK_FULLTEXT": return "Full Text";
-                        case "MEMORYCLERK_FULLTEXT_SHMEM": return "Full-text IG";
-                        case "MEMORYCLERK_HADR": return "HADR";
-                        case "MEMORYCLERK_HOST": return "Host";
-                        case "MEMORYCLERK_LANGSVC": return "Language Service";
-                        case "MEMORYCLERK_LWC": return "Light Weight Cache";
-                        case "MEMORYCLERK_QSRANGEPREFETCH": return "QS Range Prefetch";
-                        case "MEMORYCLERK_SERIALIZATION": return "Serialization";
-                        case "MEMORYCLERK_SNI": return "SNI";
-                        case "MEMORYCLERK_SOSMEMMANAGER": return "SOS Memory Manager";
-                        case "MEMORYCLERK_SOSNODE": return "SOS Node";
-                        case "MEMORYCLERK_SOSOS": return "SOS Memory Clerk";
-                        case "MEMORYCLERK_SQLBUFFERPOOL": return "Buffer Pool";
-                        case "MEMORYCLERK_SQLCLR": return "CLR";
-                        case "MEMORYCLERK_SQLCLRASSEMBLY": return "CLR Assembly";
-                        case "MEMORYCLERK_SQLCONNECTIONPOOL": return "Connection Pool";
-                        case "MEMORYCLERK_SQLGENERAL": return "General";
-                        case "MEMORYCLERK_SQLHTTP": return "HTTP";
-                        case "MEMORYCLERK_SQLLOGPOOL": return "Log Pool";
-                        case "MEMORYCLERK_SQLOPTIMIZER": return "SQL Optimizer";
-                        case "MEMORYCLERK_SQLQERESERVATIONS": return "SQL Reservations";
-                        case "MEMORYCLERK_SQLQUERYCOMPILE": return "SQL Query Compile";
-                        case "MEMORYCLERK_SQLQUERYEXEC": return "SQL Query Exec";
-                        case "MEMORYCLERK_SQLQUERYPLAN": return "SQL Query Plan";
-                        case "MEMORYCLERK_SQLSERVICEBROKER": return "SQL Service Broker";
-                        case "MEMORYCLERK_SQLSERVICEBROKERTRANSPORT": return "Unified Communication Stack";
-                        case "MEMORYCLERK_SQLSOAP": return "SQL SOAP";
-                        case "MEMORYCLERK_SQLSOAPSESSIONSTORE": return "SQL SOAP (Session Store)";
-                        case "MEMORYCLERK_SQLSTORENG": return "SQL Storage Engine";
-                        case "MEMORYCLERK_SQLUTILITIES": return "SQL Utilities";
-                        case "MEMORYCLERK_SQLXML": return "SQL XML";
-                        case "MEMORYCLERK_SQLXP": return "SQL XP";
-                        case "MEMORYCLERK_TRACE_EVTNOTIF": return "Trace Event Notification";
-                        case "MEMORYCLERK_XE": return "XE Engine";
-                        case "MEMORYCLERK_XE_BUFFER": return "XE Buffer";
-                        case "MEMORYCLERK_XTP": return "XTP Processor";
-                        case "OBJECTSTORE_LBSS": return "Lbss Cache (Object Store)";
-                        case "OBJECTSTORE_LOCK_MANAGER": return "Lock Manager (Object Store)";
-                        case "OBJECTSTORE_SECAUDIT_EVENT_BUFFER": return "Audit Event Buffer (Object Store)";
-                        case "OBJECTSTORE_SERVICE_BROKER": return "Service Broker (Object Store)";
-                        case "OBJECTSTORE_SNI_PACKET": return "SNI Packet (Object Store)";
-                        case "OBJECTSTORE_XACT_CACHE": return "Transactions Cache (Object Store)";
-                        case "USERSTORE_DBMETADATA": return "DB Metadata (User Store)";
-                        case "USERSTORE_OBJPERM": return "Object Permissions (User Store)";
-                        case "USERSTORE_SCHEMAMGR": return "Schema Manager (User Store)";
-                        case "USERSTORE_SXC": return "SXC (User Store)";
-                        case "USERSTORE_TOKENPERM": return "Token Permissions (User Store)";
-                        default:
-                            return "Other (" + ClerkType + ")";
-                    }
-                }
-            }
+                    "CACHESTORE_BROKERDSH" => "Service Broker Dialog Security Header Cache",
+                    "CACHESTORE_BROKERKEK" => "Service Broker Key Exchange Key Cache",
+                    "CACHESTORE_BROKERREADONLY" => "Service Broker (Read-Only)",
+                    "CACHESTORE_BROKERRSB" => "Service Broker Null Remote Service Binding Cache",
+                    "CACHESTORE_BROKERTBLACS" => "Broker dormant rowsets",
+                    "CACHESTORE_BROKERTO" => "Service Broker Transmission Object Cache",
+                    "CACHESTORE_BROKERUSERCERTLOOKUP" => "Service Broker user certificates lookup result cache",
+                    "CACHESTORE_CLRPROC" => "CLR Procedure Cache",
+                    "CACHESTORE_CLRUDTINFO" => "CLR UDT Info",
+                    "CACHESTORE_COLUMNSTOREOBJECTPOOL" => "Column Store Object Pool",
+                    "CACHESTORE_CONVPRI" => "Conversation Priority Cache",
+                    "CACHESTORE_EVENTS" => "Event Notification Cache",
+                    "CACHESTORE_FULLTEXTSTOPLIST" => "Full Text Stoplist Cache",
+                    "CACHESTORE_NOTIF" => "Notification Store",
+                    "CACHESTORE_OBJCP" => "Object Plans",
+                    "CACHESTORE_PHDR" => "Bound Trees",
+                    "CACHESTORE_SEARCHPROPERTYLIST" => "Search Property List Cache",
+                    "CACHESTORE_SEHOBTCOLUMNATTRIBUTE" => "SE Shared Column Metadata Cache",
+                    "CACHESTORE_SQLCP" => "SQL Plans",
+                    "CACHESTORE_STACKFRAMES" => "SOS_StackFramesStore",
+                    "CACHESTORE_SYSTEMROWSET" => "System Rowset Store",
+                    "CACHESTORE_TEMPTABLES" => "Temporary Tables & Table Variables",
+                    "CACHESTORE_VIEWDEFINITIONS" => "View Definition Cache",
+                    "CACHESTORE_XML_SELECTIVE_DG" => "XML DB Cache (Selective)",
+                    "CACHESTORE_XMLDBATTRIBUTE" => "XML DB Cache (Attribute)",
+                    "CACHESTORE_XMLDBELEMENT" => "XML DB Cache (Element)",
+                    "CACHESTORE_XMLDBTYPE" => "XML DB Cache (Type)",
+                    "CACHESTORE_XPROC" => "Extended Stored Procedures",
+                    "MEMORYCLERK_BHF" => "Best Hugging Friend (According to Brent Ozar)",
+                    "MEMORYCLERK_FILETABLE" => "Memory Clerk (File Table)",
+                    "MEMORYCLERK_FSCHUNKER" => "Memory Clerk (FS Chunker)",
+                    "MEMORYCLERK_FULLTEXT" => "Full Text",
+                    "MEMORYCLERK_FULLTEXT_SHMEM" => "Full-text IG",
+                    "MEMORYCLERK_HADR" => "HADR",
+                    "MEMORYCLERK_HOST" => "Host",
+                    "MEMORYCLERK_LANGSVC" => "Language Service",
+                    "MEMORYCLERK_LWC" => "Light Weight Cache",
+                    "MEMORYCLERK_QSRANGEPREFETCH" => "QS Range Prefetch",
+                    "MEMORYCLERK_SERIALIZATION" => "Serialization",
+                    "MEMORYCLERK_SNI" => "SNI",
+                    "MEMORYCLERK_SOSMEMMANAGER" => "SOS Memory Manager",
+                    "MEMORYCLERK_SOSNODE" => "SOS Node",
+                    "MEMORYCLERK_SOSOS" => "SOS Memory Clerk",
+                    "MEMORYCLERK_SQLBUFFERPOOL" => "Buffer Pool",
+                    "MEMORYCLERK_SQLCLR" => "CLR",
+                    "MEMORYCLERK_SQLCLRASSEMBLY" => "CLR Assembly",
+                    "MEMORYCLERK_SQLCONNECTIONPOOL" => "Connection Pool",
+                    "MEMORYCLERK_SQLGENERAL" => "General",
+                    "MEMORYCLERK_SQLHTTP" => "HTTP",
+                    "MEMORYCLERK_SQLLOGPOOL" => "Log Pool",
+                    "MEMORYCLERK_SQLOPTIMIZER" => "SQL Optimizer",
+                    "MEMORYCLERK_SQLQERESERVATIONS" => "SQL Reservations",
+                    "MEMORYCLERK_SQLQUERYCOMPILE" => "SQL Query Compile",
+                    "MEMORYCLERK_SQLQUERYEXEC" => "SQL Query Exec",
+                    "MEMORYCLERK_SQLQUERYPLAN" => "SQL Query Plan",
+                    "MEMORYCLERK_SQLSERVICEBROKER" => "SQL Service Broker",
+                    "MEMORYCLERK_SQLSERVICEBROKERTRANSPORT" => "Unified Communication Stack",
+                    "MEMORYCLERK_SQLSOAP" => "SQL SOAP",
+                    "MEMORYCLERK_SQLSOAPSESSIONSTORE" => "SQL SOAP (Session Store)",
+                    "MEMORYCLERK_SQLSTORENG" => "SQL Storage Engine",
+                    "MEMORYCLERK_SQLUTILITIES" => "SQL Utilities",
+                    "MEMORYCLERK_SQLXML" => "SQL XML",
+                    "MEMORYCLERK_SQLXP" => "SQL XP",
+                    "MEMORYCLERK_TRACE_EVTNOTIF" => "Trace Event Notification",
+                    "MEMORYCLERK_XE" => "XE Engine",
+                    "MEMORYCLERK_XE_BUFFER" => "XE Buffer",
+                    "MEMORYCLERK_XTP" => "XTP Processor",
+                    "OBJECTSTORE_LBSS" => "Lbss Cache (Object Store)",
+                    "OBJECTSTORE_LOCK_MANAGER" => "Lock Manager (Object Store)",
+                    "OBJECTSTORE_SECAUDIT_EVENT_BUFFER" => "Audit Event Buffer (Object Store)",
+                    "OBJECTSTORE_SERVICE_BROKER" => "Service Broker (Object Store)",
+                    "OBJECTSTORE_SNI_PACKET" => "SNI Packet (Object Store)",
+                    "OBJECTSTORE_XACT_CACHE" => "Transactions Cache (Object Store)",
+                    "USERSTORE_DBMETADATA" => "DB Metadata (User Store)",
+                    "USERSTORE_OBJPERM" => "Object Permissions (User Store)",
+                    "USERSTORE_SCHEMAMGR" => "Schema Manager (User Store)",
+                    "USERSTORE_SXC" => "SXC (User Store)",
+                    "USERSTORE_TOKENPERM" => "Token Permissions (User Store)",
+                    _ => "Other (" + ClerkType + ")",
+                };
 
             public bool IsBufferPool => ClerkType == "MEMORYCLERK_SQLBUFFERPOOL";
             public bool IsPlanCache => ClerkType == "CACHESTORE_SQLCP";

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Memory.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Memory.cs
@@ -6,7 +6,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<SQLMemoryClerkSummaryInfo>> _memoryClerkSummary;
-        public Cache<List<SQLMemoryClerkSummaryInfo>> MemoryClerkSummary => _memoryClerkSummary ?? (_memoryClerkSummary = SqlCacheList<SQLMemoryClerkSummaryInfo>(RefreshInterval));
+        public Cache<List<SQLMemoryClerkSummaryInfo>> MemoryClerkSummary => _memoryClerkSummary ??= SqlCacheList<SQLMemoryClerkSummaryInfo>(RefreshInterval);
 
         public class SQLMemoryClerkSummaryInfo : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.PerfCounters.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.PerfCounters.cs
@@ -8,11 +8,11 @@ namespace Opserver.Data.SQL
     {
         private Cache<List<PerfCounterRecord>> _perfCounters;
         public Cache<List<PerfCounterRecord>> PerfCounters =>
-            _perfCounters ?? (_perfCounters = GetSqlCache(nameof(PerfCounters), conn =>
+            _perfCounters ??= GetSqlCache(nameof(PerfCounters), conn =>
             {
                 var sql = GetFetchSQL<PerfCounterRecord>();
                 return conn.QueryAsync<PerfCounterRecord>(sql, new {maxEvents = 60});
-            }));
+            });
 
         public long? BatchesPerSec => (long?)GetPerfCounter("SQL Statistics", "Batch Requests/sec", "")?.CalculatedValue;
 

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Properties.cs
@@ -6,7 +6,7 @@ namespace Opserver.Data.SQL
     {
         private Cache<SQLServerProperties> _serverProperties;
         public Cache<SQLServerProperties> ServerProperties =>
-            _serverProperties ?? (_serverProperties = GetSqlCache(
+            _serverProperties ??= GetSqlCache(
                 nameof(ServerProperties), async conn =>
                 {
                     var result = await conn.QueryFirstOrDefaultAsync<SQLServerProperties>(SQLServerProperties.FetchSQL);
@@ -19,7 +19,7 @@ namespace Opserver.Data.SQL
                         }
                     }
                     return result;
-                }));
+                });
 
         public decimal? CurrentMemoryPercent { get; private set; }
 
@@ -62,7 +62,7 @@ namespace Opserver.Data.SQL
             public int CPUSocketCount => CPUCount/HyperthreadRatio;
 
             private Version _version;
-            public Version ParsedVersion => _version ?? (_version = Version != null ? System.Version.Parse(Version) : new Version(0, 0));
+            public Version ParsedVersion => _version ??= Version != null ? System.Version.Parse(Version) : new Version(0, 0);
 
             public string ShortEdition
             {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Services.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Services.cs
@@ -7,7 +7,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<SQLServiceInfo>> _services;
-        public Cache<List<SQLServiceInfo>> Services => _services ?? (_services = SqlCacheList<SQLServiceInfo>(5.Minutes()));
+        public Cache<List<SQLServiceInfo>> Services => _services ??= SqlCacheList<SQLServiceInfo>(5.Minutes());
 
         public class SQLServiceInfo : ISQLVersioned, IMonitorStatus
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
@@ -220,11 +220,11 @@ FROM (SELECT TOP (@MaxResultCount)
 
             public TopSearchOptions SetDefaults()
             {
-                Sort = Sort ?? TopSorts.AvgCPUPerMinute;
-                MinExecs = MinExecs ?? DefaultMinExecs;
-                LastRunSeconds = LastRunSeconds ?? DefaultLastRunSeconds;
-                MinLastRunDate = MinLastRunDate ?? DateTime.UtcNow.AddDays(-1);
-                MaxResultCount = MaxResultCount ?? DefaultMaxResultCount;
+                Sort ??= TopSorts.AvgCPUPerMinute;
+                MinExecs ??= DefaultMinExecs;
+                LastRunSeconds ??= DefaultLastRunSeconds;
+                MinLastRunDate ??= DateTime.UtcNow.AddDays(-1);
+                MaxResultCount ??= DefaultMaxResultCount;
                 return this;
             }
 

--- a/src/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.TopOperations.cs
@@ -76,10 +76,8 @@ namespace Opserver.Data.SQL
             {
                 if (QueryPlan == null) return new ShowPlanXML();
                 var s = new XmlSerializer(typeof(ShowPlanXML));
-                using (var r = new StringReader(QueryPlan))
-                {
-                    return (ShowPlanXML)s.Deserialize(r);
-                }
+                using var r = new StringReader(QueryPlan);
+                return (ShowPlanXML)s.Deserialize(r);
             }
 
             internal const string FetchSQL = @"

--- a/src/Opserver.Core/Data/SQL/SQLInstance.TraceFlags.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.TraceFlags.cs
@@ -6,7 +6,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<TraceFlagInfo>> _traceFlags;
-        public Cache<List<TraceFlagInfo>> TraceFlags => _traceFlags ?? (_traceFlags = SqlCacheList<TraceFlagInfo>(5.Minutes()));
+        public Cache<List<TraceFlagInfo>> TraceFlags => _traceFlags ??= SqlCacheList<TraceFlagInfo>(5.Minutes());
 
         public class TraceFlagInfo : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Utils.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Utils.cs
@@ -13,10 +13,8 @@ namespace Opserver.Data.SQL
         {
             try
             {
-                using (var conn = await GetConnectionAsync())
-                {
-                    return await conn.ExecuteAsync("DBCC FREEPROCCACHE (@planHandle);", new { planHandle });
-                }
+                using var conn = await GetConnectionAsync();
+                return await conn.ExecuteAsync("DBCC FREEPROCCACHE (@planHandle);", new { planHandle });
             }
             catch (Exception ex)
             {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.Volumes.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.Volumes.cs
@@ -6,7 +6,7 @@ namespace Opserver.Data.SQL
     public partial class SQLInstance
     {
         private Cache<List<VolumeInfo>> _volumes;
-        public Cache<List<VolumeInfo>> Volumes => _volumes ?? (_volumes = SqlCacheList<VolumeInfo>(10.Minutes()));
+        public Cache<List<VolumeInfo>> Volumes => _volumes ??= SqlCacheList<VolumeInfo>(10.Minutes());
 
         public class VolumeInfo : ISQLVersioned
         {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.WaitStats.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.WaitStats.cs
@@ -7,12 +7,12 @@ namespace Opserver.Data.SQL
     {
         private Cache<List<WaitStatRecord>> _waitStats;
         public Cache<List<WaitStatRecord>> WaitStats =>
-            _waitStats ?? (_waitStats = GetSqlCache(
+            _waitStats ??= GetSqlCache(
                 nameof(WaitStats), conn =>
                 {
                     var sql = GetFetchSQL<WaitStatRecord>();
                     return conn.QueryAsync<WaitStatRecord>(sql, new {secondsBetween = 15});
-                }));
+                });
 
         public class WaitStatRecord : ISQLVersioned
         {
@@ -26,7 +26,7 @@ namespace Opserver.Data.SQL
 
             private bool? _isIgnorable;
 
-            public bool IsIgnorable => _isIgnorable ?? (_isIgnorable = IsIgnorableWait(WaitType)).Value;
+            public bool IsIgnorable => _isIgnorable ??= IsIgnorableWait(WaitType);
 
             public static bool IsIgnorableWait(string waitType)
             {

--- a/src/Opserver.Core/Data/SQL/SQLInstance.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.cs
@@ -14,7 +14,7 @@ namespace Opserver.Data.SQL
         public string Name => Settings.Name;
         public virtual string Description => Settings.Description;
         private TimeSpan? _refreshInterval;
-        public TimeSpan RefreshInterval => _refreshInterval ?? (_refreshInterval = (Settings.RefreshIntervalSeconds ?? Module.Settings.RefreshIntervalSeconds).Seconds()).Value;
+        public TimeSpan RefreshInterval => _refreshInterval ??= (Settings.RefreshIntervalSeconds ?? Module.Settings.RefreshIntervalSeconds).Seconds();
         public string ObjectName { get; internal set; }
         public string CategoryName => "SQL";
         string ISearchableNode.DisplayName => Name;

--- a/src/Opserver.Core/Data/SQL/SQLInstance.cs
+++ b/src/Opserver.Core/Data/SQL/SQLInstance.cs
@@ -160,10 +160,8 @@ namespace Opserver.Data.SQL
                 getData: async () =>
                 {
                     if (shouldRun != null && !shouldRun()) return new T();
-                    using (var conn = await GetConnectionAsync())
-                    {
-                        return await get(conn);
-                    }
+                    using var conn = await GetConnectionAsync();
+                    return await get(conn);
                 },
                 logExceptions: logExceptions,
                 addExceptionData: e => e.AddLoggedData("Server", Name),
@@ -177,10 +175,8 @@ namespace Opserver.Data.SQL
             => LightweightCache<T>.Get(this, GetCacheKey(key),
             () =>
             {
-                using (var conn = GetConnection())
-                {
-                    return get(conn);
-                }
+                using var conn = GetConnection();
+                return get(conn);
             }, duration, staleDuration);
 
         public override string ToString() => Name;

--- a/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGInfo.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGInfo.cs
@@ -36,7 +36,7 @@ namespace Opserver.Data.SQL
 
             private bool? _hasDatabases;
             public bool HasDatabases =>
-                _hasDatabases ?? (_hasDatabases = LocalReplica?.Databases.Count > 0|| RemoteReplicas?.Sum(r => r.Databases?.Count ?? 0) > 0).Value;
+                _hasDatabases ??= LocalReplica?.Databases.Count > 0 || RemoteReplicas?.Sum(r => r.Databases?.Count ?? 0) > 0;
 
             public List<AGReplica> Replicas { get; internal set; }
             public List<AGListener> Listeners { get; internal set; }

--- a/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGListenerIPAddress.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGListenerIPAddress.cs
@@ -23,10 +23,10 @@ namespace Opserver.Data.SQL
             // and ClusterNetwork bits match here ()
 
             private IPNet _ipNet;
-            public IPNet IPNet => _ipNet ?? (_ipNet = IPNet.Parse(IPAddress, NetworkSubnetPrefixLength));
+            public IPNet IPNet => _ipNet ??= IPNet.Parse(IPAddress, NetworkSubnetPrefixLength);
 
             private IPNet _networkIPNet;
-            public IPNet NetworkIPNet => _networkIPNet ?? (_networkIPNet = IPNet.Parse(NetworkSubnetIP, NetworkSubnetPrefixLength));
+            public IPNet NetworkIPNet => _networkIPNet ??= IPNet.Parse(NetworkSubnetIP, NetworkSubnetPrefixLength);
 
             public MonitorStatus MonitorStatus
             {

--- a/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGListenerIPAddress.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGListenerIPAddress.cs
@@ -28,24 +28,15 @@ namespace Opserver.Data.SQL
             private IPNet _networkIPNet;
             public IPNet NetworkIPNet => _networkIPNet ??= IPNet.Parse(NetworkSubnetIP, NetworkSubnetPrefixLength);
 
-            public MonitorStatus MonitorStatus
-            {
-                get
+            public MonitorStatus MonitorStatus =>
+                State switch
                 {
-                    switch (State)
-                    {
-                        case ListenerStates.Online:
-                            return MonitorStatus.Good;
-                        case ListenerStates.OnlinePending:
-                            return MonitorStatus.Warning;
-                        case ListenerStates.Failed:
-                            return MonitorStatus.Critical;
-                        //case ListenerStates.Offline:
-                        default:
-                            return MonitorStatus.Unknown;
-                    }
-                }
-            }
+                    ListenerStates.Online => MonitorStatus.Good,
+                    ListenerStates.OnlinePending => MonitorStatus.Warning,
+                    ListenerStates.Failed => MonitorStatus.Critical,
+                    //case ListenerStates.Offline:
+                    _ => MonitorStatus.Unknown,
+                };
 
             public string MonitorStatusReason => State.ToString();
 

--- a/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGReplica.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.AGReplica.cs
@@ -73,16 +73,13 @@ namespace Opserver.Data.SQL
                     }
                     if (SynchronizationHealth.HasValue)
                     {
-                        switch (SynchronizationHealth.Value)
+                        return SynchronizationHealth.Value switch
                         {
-                            case SynchronizationHealths.NotHealthy:
-                                return MonitorStatus.Critical;
-                            case SynchronizationHealths.PartiallyHealthy:
-                                return MonitorStatus.Warning;
+                            SynchronizationHealths.NotHealthy => MonitorStatus.Critical,
+                            SynchronizationHealths.PartiallyHealthy => MonitorStatus.Warning,
                             //case SynchronizationHealths.Healthy:
-                            default:
-                                return MonitorStatus.Good;
-                        }
+                            _ => MonitorStatus.Good,
+                        };
                     }
                     return Databases.GetWorstStatus();
                 }

--- a/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.AvailabilityGroups.cs
@@ -8,7 +8,7 @@ namespace Opserver.Data.SQL
     {
         private Cache<List<AGInfo>> _availabilityGroups;
         public Cache<List<AGInfo>> AvailabilityGroups =>
-            _availabilityGroups ?? (_availabilityGroups = GetSqlCache(nameof(AvailabilityGroups), async conn =>
+            _availabilityGroups ??= GetSqlCache(nameof(AvailabilityGroups), async conn =>
             {
                 PerfCounterRecord getCounter(string cn, string n) => GetPerfCounter("Availability Replica", cn, n);
                 var sql = QueryLookup.GetOrAdd(Tuple.Create(nameof(AvailabilityGroups), Version), k =>
@@ -64,6 +64,6 @@ namespace Opserver.Data.SQL
                     }
                 }
                 return ags;
-            }));
+            });
     }
 }

--- a/src/Opserver.Core/Data/SQL/SQLNode.ClusterInfo.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.ClusterInfo.cs
@@ -8,7 +8,7 @@ namespace Opserver.Data.SQL
         private Cache<AGClusterState> _agClusterInfo;
 
         public Cache<AGClusterState> AGClusterInfo =>
-            _agClusterInfo ?? (_agClusterInfo = GetSqlCache(nameof(AGClusterInfo), async conn =>
+            _agClusterInfo ??= GetSqlCache(nameof(AGClusterInfo), async conn =>
             {
                 var sql = QueryLookup.GetOrAdd(Tuple.Create(nameof(AGClusterInfo), Version), k =>
                         GetFetchSQL<AGClusterState>(k.Item2) + "\n" +
@@ -34,7 +34,7 @@ namespace Opserver.Data.SQL
                     }
                 }
                 return state;
-            }));
+            });
 
         public class AGClusterState : ISQLVersioned
         {
@@ -85,7 +85,7 @@ Select member_name MemberName,
 
             private IPNet _networkIPNet;
             public IPNet NetworkIPNet =>
-                _networkIPNet ?? (_networkIPNet = IPNet.Parse(NetworkSubnetIP, NetworkSubnetPrefixLength));
+                _networkIPNet ??= IPNet.Parse(NetworkSubnetIP, NetworkSubnetPrefixLength);
 
             public string GetFetchSQL(Version v) => @"
 Select member_name MemberName,

--- a/src/Opserver.Core/Data/SQL/SQLNode.TCPListeners.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.TCPListeners.cs
@@ -18,21 +18,13 @@ namespace Opserver.Data.SQL
         {
             Version IMinVersioned.MinVersion => SQLServerVersions.SQL2012.RTM;
 
-            public MonitorStatus MonitorStatus
-            {
-                get
+            public MonitorStatus MonitorStatus =>
+                State switch
                 {
-                    switch (State)
-                    {
-                        case TCPListenerStates.Online:
-                            return MonitorStatus.Good;
-                        case TCPListenerStates.PendingRestart:
-                            return MonitorStatus.Maintenance;
-                        default:
-                            return MonitorStatus.Unknown;
-                    }
-                }
-            }
+                    TCPListenerStates.Online => MonitorStatus.Good,
+                    TCPListenerStates.PendingRestart => MonitorStatus.Maintenance,
+                    _ => MonitorStatus.Unknown,
+                };
 
             public string MonitorStatusReason => State == TCPListenerStates.Online ? null : State.AsString(EnumFormat.Description);
 

--- a/src/Opserver.Core/Data/SQL/SQLNode.TCPListeners.cs
+++ b/src/Opserver.Core/Data/SQL/SQLNode.TCPListeners.cs
@@ -9,7 +9,7 @@ namespace Opserver.Data.SQL
         private Cache<List<TCPListenerState>> _tcpListeners;
 
         public Cache<List<TCPListenerState>> TCPListeners =>
-            _tcpListeners ?? (_tcpListeners = SqlCacheList<TCPListenerState>(Cluster.RefreshInterval));
+            _tcpListeners ??= SqlCacheList<TCPListenerState>(Cluster.RefreshInterval);
 
         /// <summary>
         /// http://msdn.microsoft.com/en-us/library/hh245287.aspx

--- a/src/Opserver.Core/Helpers/Connection.cs
+++ b/src/Opserver.Core/Helpers/Connection.cs
@@ -24,11 +24,9 @@ namespace Opserver.Helpers
             var conn = new ProfiledDbConnection(new SqlConnection(connectionString), MiniProfiler.Current);
             static void setReadUncommitted(DbConnection c)
             {
-                using (var cmd = c.CreateCommand())
-                {
-                    cmd.CommandText = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED";
-                    cmd.ExecuteNonQuery();
-                }
+                using var cmd = c.CreateCommand();
+                cmd.CommandText = "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED";
+                cmd.ExecuteNonQuery();
             }
 
             if (connectionTimeoutMs.GetValueOrDefault(0) == 0)

--- a/src/Opserver.Core/Helpers/Connection.cs
+++ b/src/Opserver.Core/Helpers/Connection.cs
@@ -22,7 +22,7 @@ namespace Opserver.Helpers
         public static DbConnection GetOpen(string connectionString, int? connectionTimeoutMs = null)
         {
             var conn = new ProfiledDbConnection(new SqlConnection(connectionString), MiniProfiler.Current);
-            void setReadUncommitted(DbConnection c)
+            static void setReadUncommitted(DbConnection c)
             {
                 using (var cmd = c.CreateCommand())
                 {

--- a/src/Opserver.Core/Helpers/PerfCounters.cs
+++ b/src/Opserver.Core/Helpers/PerfCounters.cs
@@ -27,16 +27,14 @@ namespace Opserver.Helpers
                 var timer = Stopwatch.StartNew();
 
                 // TODO: Poll creds
-                using (var q = new Wmi.WmiQuery(machineName, query))
+                using var q = new Wmi.WmiQuery(machineName, query);
+                var queryResults = (await q.Result).Cast<ManagementObject>();
+                timer.Stop();
+                return new QueryResult<T>
                 {
-                    var queryResults = (await q.Result).Cast<ManagementObject>();
-                    timer.Stop();
-                    return new QueryResult<T>
-                        {
-                            Duration = timer.Elapsed,
-                            Data = conversion(queryResults).ToList()
-                        };
-                }
+                    Duration = timer.Elapsed,
+                    Data = conversion(queryResults).ToList()
+                };
             }
         }
 

--- a/src/Opserver.Core/Settings/DashboardSettings.cs
+++ b/src/Opserver.Core/Settings/DashboardSettings.cs
@@ -70,7 +70,7 @@ namespace Opserver
         private Regex _servicesPatternRegEx;
         public Regex ServicesPatternRegEx
         {
-            get => _servicesPatternRegEx ?? (_servicesPatternRegEx = GetPatternMatcher(ServicesPattern));
+            get => _servicesPatternRegEx ??= GetPatternMatcher(ServicesPattern);
             set => _servicesPatternRegEx = value;
         }
 
@@ -96,7 +96,7 @@ namespace Opserver
             /// <summary>
             /// The pattern to match for these node settings
             /// </summary>
-            public Regex PatternRegex => _patternRegEx ?? (_patternRegEx = GetPatternMatcher(Pattern));
+            public Regex PatternRegex => _patternRegEx ??= GetPatternMatcher(Pattern);
 
             /// <summary>
             /// The Pattern to match on node interfaces, an interface matching this pattern will be shown on the dashboard.
@@ -106,7 +106,7 @@ namespace Opserver
             private Regex _primaryInterfacePatternRegEx;
             public Regex PrimaryInterfacePatternRegex
             {
-                get => _primaryInterfacePatternRegEx ?? (_primaryInterfacePatternRegEx = GetPatternMatcher(PrimaryInterfacePattern));
+                get => _primaryInterfacePatternRegEx ??= GetPatternMatcher(PrimaryInterfacePattern);
                 set => _primaryInterfacePatternRegEx = value;
             }
 
@@ -148,7 +148,7 @@ namespace Opserver
             private Regex _servicesPatternRegEx;
             public Regex ServicesPatternRegEx
             {
-                get => _servicesPatternRegEx ?? (_servicesPatternRegEx = GetPatternMatcher(ServicesPattern));
+                get => _servicesPatternRegEx ??= GetPatternMatcher(ServicesPattern);
                 set => _servicesPatternRegEx = value;
             }
         }
@@ -170,7 +170,7 @@ namespace Opserver
             /// <summary>
             /// The pattern to match for these node settings
             /// </summary>
-            public Regex PatternRegex => _patternRegEx ?? (_patternRegEx = GetPatternMatcher(Pattern));
+            public Regex PatternRegex => _patternRegEx ??= GetPatternMatcher(Pattern);
 
             /// <summary>
             /// The Pattern to match on node interfaces, an interface matching this pattern will be shown on the dashboard.
@@ -180,7 +180,7 @@ namespace Opserver
             private Regex _primaryInterfacePatternRegEx;
             public Regex PrimaryInterfacePatternRegex
             {
-                get => _primaryInterfacePatternRegEx ?? (_primaryInterfacePatternRegEx = GetPatternMatcher(PrimaryInterfacePattern));
+                get => _primaryInterfacePatternRegEx ??= GetPatternMatcher(PrimaryInterfacePattern);
                 set => _primaryInterfacePatternRegEx = value;
             }
 
@@ -222,7 +222,7 @@ namespace Opserver
             private Regex _servicesPatternRegEx;
             public Regex ServicesPatternRegEx
             {
-                get => _servicesPatternRegEx ?? (_servicesPatternRegEx = GetPatternMatcher(ServicesPattern));
+                get => _servicesPatternRegEx ??= GetPatternMatcher(ServicesPattern);
                 set => _servicesPatternRegEx = value;
             }
         }

--- a/src/Opserver.Core/Settings/ExceptionSettings.cs
+++ b/src/Opserver.Core/Settings/ExceptionSettings.cs
@@ -24,7 +24,7 @@ namespace Opserver
         public List<StackTraceSourceLinkPattern> StackTraceReplacements { get; set; } = new List<StackTraceSourceLinkPattern>();
 
         private StackTraceSettings _stackTraceSettings;
-        public StackTraceSettings StackTraceSettings => _stackTraceSettings ?? (_stackTraceSettings = GetStackTraceSettings());
+        public StackTraceSettings StackTraceSettings => _stackTraceSettings ??= GetStackTraceSettings();
 
         /// <summary>
         /// How many exceptions before the exceptions are highlighted as a warning in the header, null (default) is ignored

--- a/src/Opserver.Core/Settings/RedisSettings.cs
+++ b/src/Opserver.Core/Settings/RedisSettings.cs
@@ -28,12 +28,12 @@ namespace Opserver
             /// <summary>
             /// The pattern to match against a host to get the region portion (e.g. a datacenter).
             /// </summary>
-            public Regex RegionHostRegex => _regionHostRegex ?? (_regionHostRegex = GetRegex(RegionHostPattern));
+            public Regex RegionHostRegex => _regionHostRegex ??= GetRegex(RegionHostPattern);
 
             /// <summary>
             /// The pattern to match against a host to get the region portion (e.g. a datacenter).
             /// </summary>
-            public Regex CrossRegionNameRegex => _crossRegionNameRegex ?? (_crossRegionNameRegex = GetRegex(CrossRegionNamePattern));
+            public Regex CrossRegionNameRegex => _crossRegionNameRegex ??= GetRegex(CrossRegionNamePattern);
 
             private static Regex GetRegex(string pattern) =>
                 pattern.IsNullOrEmpty() ? null : new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);

--- a/src/Opserver.Web/Controllers/DashboardController.cs
+++ b/src/Opserver.Web/Controllers/DashboardController.cs
@@ -99,15 +99,12 @@ namespace Opserver.Controllers
         public ActionResult InstanceSummary(string node, string type)
         {
             var n = Module.GetNodeByName(node);
-            switch (type)
+            return type switch
             {
-                case "hardware":
-                    return View("Node.Hardware", n);
-                case "network":
-                    return View("Node.Network", n);
-                default:
-                    return ContentNotFound("Unknown summary view requested");
-            }
+                "hardware" => View("Node.Hardware", n),
+                "network" => View("Node.Network", n),
+                _ => ContentNotFound("Unknown summary view requested"),
+            };
         }
 
         [Route("dashboard/graph/{nodeId}/{type}")]

--- a/src/Opserver.Web/Controllers/ElasticController.cs
+++ b/src/Opserver.Web/Controllers/ElasticController.cs
@@ -44,39 +44,33 @@ namespace Opserver.Controllers
         public ActionResult NodeModal(string cluster, string node, string type)
         {
             var vd = GetViewData(cluster, node);
-            switch (type)
+            return type switch
             {
-                case "settings":
-                    return View("Node.Settings", vd);
-                default:
-                    return ContentNotFound("Unknown modal view requested");
-            }
+                "settings" => View("Node.Settings", vd),
+                _ => ContentNotFound("Unknown modal view requested"),
+            };
         }
 
         [Route("elastic/cluster/modal/{type}")]
         public ActionResult ClusterModal(string cluster, string node, string type)
         {
             var vd = GetViewData(cluster, node);
-            switch (type)
+            return type switch
             {
-                case "indexes":
-                    return View("Cluster.Indexes", vd);
-                default:
-                    return ContentNotFound("Unknown modal view requested");
-            }
+                "indexes" => View("Cluster.Indexes", vd),
+                _ => ContentNotFound("Unknown modal view requested"),
+            };
         }
 
         [Route("elastic/index/modal/{type}")]
         public ActionResult IndexModal(string cluster, string node, string index, string type)
         {
             var vd = GetViewData(cluster, node, index);
-            switch (type)
+            return type switch
             {
-                case "shards":
-                    return View("Cluster.Shards", vd);
-                default:
-                    return ContentNotFound("Unknown modal view requested");
-            }
+                "shards" => View("Cluster.Shards", vd),
+                _ => ContentNotFound("Unknown modal view requested"),
+            };
         }
 
         private DashboardModel GetViewData(string cluster, string node = null, string index = null)

--- a/src/Opserver.Web/Controllers/PagerDutyController.Admin.cs
+++ b/src/Opserver.Web/Controllers/PagerDutyController.Admin.cs
@@ -31,7 +31,7 @@ namespace Opserver.Controllers
                    : "PagerDuty Schedule '" + Module.Settings.PrimaryScheduleName + "' not found.");
             }
 
-            start = start ?? DateTime.UtcNow;
+            start ??= DateTime.UtcNow;
 
             await Module.API.SetOverrideAsync(currentPrimarySchedule, start.Value, start.Value.AddMinutes(durationMins), CurrentPagerDutyPerson);
 

--- a/src/Opserver.Web/Controllers/RedisController.cs
+++ b/src/Opserver.Web/Controllers/RedisController.cs
@@ -61,19 +61,14 @@ namespace Opserver.Controllers
             var i = Module.GetInstance(node);
             if (i == null) return ContentNotFound("Could not find instance " + node);
 
-            switch (type)
+            return type switch
             {
-                case "config":
-                    return View("Instance.Config", i);
-                case "clients":
-                    return View("Instance.Clients", i);
-                case "info":
-                    return View("Instance.Info", i);
-                case "slow-log":
-                    return View("Instance.SlowLog", i);
-                default:
-                    return ContentNotFound("Unknown summary view requested");
-            }
+                "config" => View("Instance.Config", i),
+                "clients" => View("Instance.Clients", i),
+                "info" => View("Instance.Info", i),
+                "slow-log" => View("Instance.SlowLog", i),
+                _ => ContentNotFound("Unknown summary view requested"),
+            };
         }
 
         [Route("redis/analyze/memory")]

--- a/src/Opserver.Web/Controllers/SQLController.cs
+++ b/src/Opserver.Web/Controllers/SQLController.cs
@@ -76,23 +76,16 @@ namespace Opserver.Controllers
             var i = Module.GetInstance(node);
             if (i == null) return NoInstanceRedirect(node);
 
-            switch (type)
+            return type switch
             {
-                case "configuration":
-                    return View("Instance.Configuration", i);
-                case "connections":
-                    return View("Instance.Connections", i);
-                case "errors":
-                    return View("Instance.Errors", i);
-                case "memory":
-                    return View("Instance.Memory", i);
-                case "jobs":
-                    return View("Instance.Jobs", i);
-                case "db-files":
-                    return View("Instance.DBFiles", i);
-                default:
-                    return ContentNotFound("Unknown summary view requested");
-            }
+                "configuration" => View("Instance.Configuration", i),
+                "connections" => View("Instance.Connections", i),
+                "errors" => View("Instance.Errors", i),
+                "memory" => View("Instance.Memory", i),
+                "jobs" => View("Instance.Jobs", i),
+                "db-files" => View("Instance.DBFiles", i),
+                _ => ContentNotFound("Unknown summary view requested"),
+            };
         }
 
         [ResponseCache(Duration = 5 * 1, VaryByQueryKeys = new string[] { "node", "sort", "options" })]

--- a/src/Opserver.Web/Current.cs
+++ b/src/Opserver.Web/Current.cs
@@ -39,7 +39,7 @@ namespace Opserver
             /// <summary>
             /// The current theme were on.
             /// </summary>
-            public string Theme => _theme ?? (_theme = Helpers.Theme.Get(HttpContext.Request));
+            public string Theme => _theme ??= Helpers.Theme.Get(HttpContext.Request);
 
             private User _user;
             /// <summary>

--- a/src/Opserver.Web/ExtensionMethods.cs
+++ b/src/Opserver.Web/ExtensionMethods.cs
@@ -298,7 +298,7 @@ namespace Opserver
         {
             // TODO: Make this a setting?
             // UTC Time is good for Stack Exchange but many people don't run their servers on UTC
-            compareTo = compareTo ?? DateTime.UtcNow;
+            compareTo ??= DateTime.UtcNow;
             return $@"<span title=""{dt.ToString("u")}"" class=""js-relative-time {cssClass}"">{dt.ToRelativeTime(asPlusMinus: asPlusMinus, compareTo: compareTo)}</span>".AsHtml();
         }
 

--- a/src/Opserver.Web/ExtensionMethods.cs
+++ b/src/Opserver.Web/ExtensionMethods.cs
@@ -52,29 +52,21 @@ namespace Opserver
         {
             if (item.Status == "UP") return HtmlString.Empty;
 
-            switch (item.MonitorStatus)
+            return item.MonitorStatus switch
             {
-                case MonitorStatus.Good:
-                    return ("(" + item.Status + ")").AsHtml();
-                default:
-                    return ("(<b>" + item.Status + "</b>)").AsHtml();
-            }
+                MonitorStatus.Good => ("(" + item.Status + ")").AsHtml(),
+                _ => ("(<b>" + item.Status + "</b>)").AsHtml(),
+            };
         }
 
-        public static HtmlString ColorCode(this string s)
-        {
-            switch (s)
+        public static HtmlString ColorCode(this string s) =>
+            s switch
             {
-                case "None":
-                    return @"<span class=""text-muted"">None</span>".AsHtml();
-                case "Unknown":
-                    return @"<span class=""text-warning"">Unknown</span>".AsHtml();
-                case "n/a":
-                    return @"<span class=""text-warning"">n/a</span>".AsHtml();
-                default:
-                    return s.HtmlEncode().AsHtml();
-            }
-        }
+                "None" => @"<span class=""text-muted"">None</span>".AsHtml(),
+                "Unknown" => @"<span class=""text-warning"">Unknown</span>".AsHtml(),
+                "n/a" => @"<span class=""text-warning"">n/a</span>".AsHtml(),
+                _ => s.HtmlEncode().AsHtml(),
+            };
 
         /// <summary>
         /// Returns an icon span representation of this MonitorStatus.
@@ -107,18 +99,14 @@ namespace Opserver
                 return @"<span class=""text-muted"">●</span>".AsHtml();
 
             var monitorStatusClass = node.MonitorStatus.TextClass(true);
-            switch (node.HardwareType)
+            return node.HardwareType switch
             {
-                case HardwareType.Physical:
-                    return $@"<i class=""{monitorStatusClass} fa fa-server"" aria-hidden=""true"" title=""Physical""></i>".AsHtml();
-                case HardwareType.VirtualMachine:
-                    return $@"<i class=""{monitorStatusClass} fa fa-cloud"" aria-hidden=""true"" title=""Virtual Machine""></i>".AsHtml();
-                case HardwareType.Network:
-                    return $@"<i class=""{monitorStatusClass} fa fa-exchange"" aria-hidden=""true"" title=""Network""></i>".AsHtml();
+                HardwareType.Physical => $@"<i class=""{monitorStatusClass} fa fa-server"" aria-hidden=""true"" title=""Physical""></i>".AsHtml(),
+                HardwareType.VirtualMachine => $@"<i class=""{monitorStatusClass} fa fa-cloud"" aria-hidden=""true"" title=""Virtual Machine""></i>".AsHtml(),
+                HardwareType.Network => $@"<i class=""{monitorStatusClass} fa fa-exchange"" aria-hidden=""true"" title=""Network""></i>".AsHtml(),
                 //case HardwareType.Unknown:
-                default:
-                    return $@"<i class=""{monitorStatusClass} fa fa-question-circle-o"" aria-hidden=""true"" title=""Unknown hardware type""></i>".AsHtml();
-            }
+                _ => $@"<i class=""{monitorStatusClass} fa fa-question-circle-o"" aria-hidden=""true"" title=""Unknown hardware type""></i>".AsHtml(),
+            };
         }
 
         public static HtmlString IconSpan(this IMonitorStatus status)
@@ -149,74 +137,49 @@ namespace Opserver
             }
         }
 
-        public static HtmlString Span(this MonitorStatus status, string text, string tooltip = null)
-        {
-            switch (status)
+        public static HtmlString Span(this MonitorStatus status, string text, string tooltip = null) =>
+            status switch
             {
-                case MonitorStatus.Good:
-                    return StatusIndicator.UpCustomSpan(text, tooltip);
-                case MonitorStatus.Warning:
-                    return StatusIndicator.WarningCustomSpan(text, tooltip);
-                case MonitorStatus.Critical:
-                    return StatusIndicator.DownCustomSpan(text, tooltip);
-                default:
-                    return StatusIndicator.UnknownCustomSpan(text, tooltip);
-            }
-        }
+                MonitorStatus.Good => StatusIndicator.UpCustomSpan(text, tooltip),
+                MonitorStatus.Warning => StatusIndicator.WarningCustomSpan(text, tooltip),
+                MonitorStatus.Critical => StatusIndicator.DownCustomSpan(text, tooltip),
+                _ => StatusIndicator.UnknownCustomSpan(text, tooltip),
+            };
 
         public static string RawClass(this IMonitorStatus status) => RawClass(status.MonitorStatus);
-        public static string RawClass(this MonitorStatus status, bool showGood = false, bool maint = false)
-        {
-            switch (status)
+        public static string RawClass(this MonitorStatus status, bool showGood = false, bool maint = false) =>
+            status switch
             {
-                case MonitorStatus.Good:
-                    return showGood ? "success" : "";
-                case MonitorStatus.Warning:
-                    return "warning";
-                case MonitorStatus.Critical:
-                    return "danger";
-                case MonitorStatus.Maintenance:
-                    return maint ? "info" : "muted";
-                default:
-                    return "muted";
-            }
-        }
+                MonitorStatus.Good => showGood ? "success" : "",
+                MonitorStatus.Warning => "warning",
+                MonitorStatus.Critical => "danger",
+                MonitorStatus.Maintenance => maint ? "info" : "muted",
+                _ => "muted",
+            };
 
         public static string RowClass(this IMonitorStatus status) => RawClass(status.MonitorStatus);
         public static string RowClass(this MonitorStatus status) => RawClass(status);
 
         public static string TextClass(this IMonitorStatus status) => TextClass(status.MonitorStatus);
-        public static string TextClass(this MonitorStatus status, bool showGood = false)
-        {
-            switch (status)
+        public static string TextClass(this MonitorStatus status, bool showGood = false) =>
+            status switch
             {
-                case MonitorStatus.Good:
-                    return showGood ? "text-success" : "";
-                case MonitorStatus.Warning:
-                    return "text-warning";
-                case MonitorStatus.Critical:
-                    return "text-danger";
+                MonitorStatus.Good => showGood ? "text-success" : "",
+                MonitorStatus.Warning => "text-warning",
+                MonitorStatus.Critical => "text-danger",
                 //case MonitorStatus.Maintenance:
-                default:
-                    return "text-muted";
-            }
-        }
+                _ => "text-muted",
+            };
 
         public static string BackgroundClass(this IMonitorStatus status) => BackgroundClass(status.MonitorStatus);
-        public static string BackgroundClass(this MonitorStatus status, bool showGood = true)
-        {
-            switch (status)
+        public static string BackgroundClass(this MonitorStatus status, bool showGood = true) =>
+            status switch
             {
-                case MonitorStatus.Good:
-                    return showGood ? "bg-success" : "";
-                case MonitorStatus.Warning:
-                    return "bg-warning";
-                case MonitorStatus.Critical:
-                    return "bg-danger";
-                default:
-                    return "bg-muted";
-            }
-        }
+                MonitorStatus.Good => showGood ? "bg-success" : "",
+                MonitorStatus.Warning => "bg-warning",
+                MonitorStatus.Critical => "bg-danger",
+                _ => "bg-muted",
+            };
 
         public static string ProgressBarClass(this MonitorStatus status)
         {
@@ -569,16 +532,13 @@ namespace Opserver
         {
             var desc = state.HasValue ? state.Value.AsString(EnumFormat.Description) : "";
             if (abbreviate) desc = desc.Substring(0, 1);
-            switch (state)
+            return state switch
             {
-                case ReplicaRoles.Primary:
-                    return StatusIndicator.UpCustomSpan(desc, tooltip);
-                case ReplicaRoles.Secondary:
-                    return desc.AsHtml();
+                ReplicaRoles.Primary => StatusIndicator.UpCustomSpan(desc, tooltip),
+                ReplicaRoles.Secondary => desc.AsHtml(),
                 //case ReplicaRoles.Resolving:
-                default:
-                    return StatusIndicator.DownCustomSpan(desc, tooltip);
-            }
+                _ => StatusIndicator.DownCustomSpan(desc, tooltip),
+            };
         }
     }
 }

--- a/src/Opserver.Web/Security/ActiveDirectoryProvider.cs
+++ b/src/Opserver.Web/Security/ActiveDirectoryProvider.cs
@@ -65,10 +65,8 @@ namespace Opserver.Security
                     {
                         var group = RunCommand(pc =>
                             {
-                                using (var gp = GroupPrincipal.FindByIdentity(pc, groupName))
-                                {
-                                    return gp?.GetMembers(true).ToList().Select(mp => mp.SamAccountName).ToList() ?? new List<string>();
-                                }
+                                using var gp = GroupPrincipal.FindByIdentity(pc, groupName);
+                                return gp?.GetMembers(true).ToList().Select(mp => mp.SamAccountName).ToList() ?? new List<string>();
                             });
                         return group ?? old ?? new List<string>();
                     }
@@ -83,12 +81,9 @@ namespace Opserver.Security
                 {
                     try
                     {
-                        using (var pc = UserAuth
-                                            ? new PrincipalContext(ContextType.Domain, s, AuthUser, AuthPassword)
-                                            : new PrincipalContext(ContextType.Domain, s))
-                        {
-                            return command(pc);
-                        }
+                        using var pc = UserAuth ? new PrincipalContext(ContextType.Domain, s, AuthUser, AuthPassword)
+                                                : new PrincipalContext(ContextType.Domain, s);
+                        return command(pc);
                     }
                     catch (Exception ex)
                     {
@@ -102,8 +97,8 @@ namespace Opserver.Security
                 // try the current domain
                 try
                 {
-                    using (var pc = new PrincipalContext(ContextType.Domain))
-                        return command(pc);
+                    using var pc = new PrincipalContext(ContextType.Domain);
+                    return command(pc);
                 }
                 catch (Exception ex)
                 {

--- a/src/Opserver.Web/Security/SecurityManager.cs
+++ b/src/Opserver.Web/Security/SecurityManager.cs
@@ -14,18 +14,13 @@ namespace Opserver.Security
             CurrentProvider = GetProvider(settings.Value, cache);
         }
 
-        private SecurityProvider GetProvider(SecuritySettings settings, IMemoryCache cache)
-        {
-            switch (settings.Provider)
+        private SecurityProvider GetProvider(SecuritySettings settings, IMemoryCache cache) =>
+            settings.Provider switch
             {
-                case "ActiveDirectory":
-                    return new ActiveDirectoryProvider(settings, cache);
-                case "EveryonesAnAdmin":
-                    return new EveryonesAnAdminProvider(settings);
+                "ActiveDirectory" => new ActiveDirectoryProvider(settings, cache),
+                "EveryonesAnAdmin" => new EveryonesAnAdminProvider(settings),
                 //case "EveryonesReadOnly":
-                default:
-                    return new EveryonesReadOnlyProvider(settings);
-            }
-        }
+                _ => new EveryonesReadOnlyProvider(settings),
+            };
     }
 }

--- a/src/Opserver.Web/Views/Elastic/Dashboard.Model.cs
+++ b/src/Opserver.Web/Views/Elastic/Dashboard.Model.cs
@@ -25,39 +25,23 @@ namespace Opserver.Views.Elastic
             WarningsOnly
         }
 
-        public IEnumerable<ElasticCluster.ClusterHealthInfo.IndexHealthInfo> DisplayIndexexs
-        {
-            get
+        public IEnumerable<ElasticCluster.ClusterHealthInfo.IndexHealthInfo> DisplayIndexexs =>
+            DisplayMode switch
             {
-                switch (DisplayMode)
-                {
-                    case DisplayModes.InterestingOnly:
-                        return CurrentCluster?.TroubledIndexes; // TODO: Differentiate both
-                    case DisplayModes.WarningsOnly:
-                        return CurrentCluster?.TroubledIndexes;
-                    //case DashboardModel.DisplayModes.All:
-                    default:
-                return CurrentCluster?.HealthStatus.Data?.Indexes?.Values;
-                }
-            }
-        }
+                DisplayModes.InterestingOnly => CurrentCluster?.TroubledIndexes,// TODO: Differentiate both
+                DisplayModes.WarningsOnly => CurrentCluster?.TroubledIndexes,
+                //case DashboardModel.DisplayModes.All:
+                _ => CurrentCluster?.HealthStatus.Data?.Indexes?.Values,
+            };
 
-        public IEnumerable<ElasticCluster.ClusterStateInfo.ShardState> DisplayShards
-        {
-            get
+        public IEnumerable<ElasticCluster.ClusterStateInfo.ShardState> DisplayShards =>
+            DisplayMode switch
             {
-                switch (DisplayMode)
-                {
-                    case DisplayModes.InterestingOnly:
-                        return CurrentCluster?.TroubledShards; // TODO: Differentiate both
-                    case DisplayModes.WarningsOnly:
-                        return CurrentCluster?.TroubledShards;
-                    //case DashboardModel.DisplayModes.All:
-                    default:
-                        return CurrentCluster?.AllShards;
-                }
-            }
-        }
+                DisplayModes.InterestingOnly => CurrentCluster?.TroubledShards,// TODO: Differentiate both
+                DisplayModes.WarningsOnly => CurrentCluster?.TroubledShards,
+                //case DashboardModel.DisplayModes.All:
+                _ => CurrentCluster?.AllShards,
+            };
 
         public Views View { get; set; }
 

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Model.cs
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Model.cs
@@ -11,7 +11,7 @@ namespace Opserver.Views.Exceptions
     public class ExceptionsModel
     {
         private NameValueCollection _requestQueryString;
-        public NameValueCollection RequestQueryString => _requestQueryString ?? (_requestQueryString = HttpUtility.ParseQueryString(Current.Request.QueryString.ToString()));
+        public NameValueCollection RequestQueryString => _requestQueryString ??= HttpUtility.ParseQueryString(Current.Request.QueryString.ToString());
 
         public ExceptionsModule Module { get; internal set; }
         public ExceptionStore Store { get; internal set; }
@@ -27,14 +27,14 @@ namespace Opserver.Views.Exceptions
 
         public bool ShowAll => Group == null && Log == null;
         private int? _shownCount;
-        public int ShownCount => _shownCount ?? (_shownCount = Errors.Sum(e => e.DuplicateCount)).Value;
+        public int ShownCount => _shownCount ??= Errors.Sum(e => e.DuplicateCount) ?? 0;
         public bool ShowClearLink => Current.User.Is(ExceptionsRoles.Admin) && Errors.Any(e => !e.IsProtected) && (Log != null || SearchParams.SearchQuery.HasValue() || SearchParams.SearchQuery.HasValue());
         public bool ShowDeleted { get; set; }
 
         public int LoadAsyncSize { get; set; }
 
         private int? _totalCount;
-        public int TotalCount => _totalCount ?? (_totalCount = GetTotal()).Value;
+        public int TotalCount => _totalCount ??= GetTotal();
         private int GetTotal() => Log?.ExceptionCount ?? Group?.Total ?? Store?.TotalExceptionCount ?? Module.TotalExceptionCount;
 
         public bool HasMore => TotalCount > ShownCount;

--- a/src/Opserver.Web/Views/Redis/Dashboard.Model.cs
+++ b/src/Opserver.Web/Views/Redis/Dashboard.Model.cs
@@ -22,10 +22,7 @@ namespace Opserver.Views.Redis
         public RedisViews View { get; set; }
 
         public bool? _allVersionsMatch;
-        public bool AllVersionsMatch
-        {
-            get { return _allVersionsMatch ?? (_allVersionsMatch = Instances?.All(i => i.Version == Instances[0].Version) == true).Value; }
-        }
+        public bool AllVersionsMatch => _allVersionsMatch ??= Instances?.All(i => i.Version == Instances[0].Version) == true;
 
         public Version CommonVersion => AllVersionsMatch ? Instances[0].Version : null;
 

--- a/src/Opserver.Web/Views/SQL/Operations.Top.Model.cs
+++ b/src/Opserver.Web/Views/SQL/Operations.Top.Model.cs
@@ -11,8 +11,7 @@ namespace Opserver.Views.SQL
         public List<SQLInstance.TopOperation> TopOperations { get; set; }
 
         private HtmlString _topSearchOptionsQueryString;
-        public HtmlString TopSearchOptionsQueryString =>
-            _topSearchOptionsQueryString ?? (_topSearchOptionsQueryString = GetQueryString(TopSearchOptions));
+        public HtmlString TopSearchOptionsQueryString => _topSearchOptionsQueryString ??= GetQueryString(TopSearchOptions);
 
         public static HtmlString GetQueryString(SQLInstance.TopSearchOptions options)
         {


### PR DESCRIPTION
Since `craver/aspnetcore` is building against `netcoreapp3.0`+, we can use C# 8 here.

I'm doing this as a separate PR for anyone curious. It's broken into 3 commits to illustrate the major wins for Opserver, mainly:
- `Prop => field ??= Fetch();` instead of `Prop => field ?? (field = Fetch());`
- Simplified `using` statements (I don't see this as a huge win in readability except in very few cases)
- `switch` expressions - these make the "decode" cases for translating APIs and statuses much, much more readable

You can browse by commits in this PR to see examples on each of the categories.