### PR TITLE
Added SslProtocols to the redisSettings config

### DIFF
--- a/Opserver.Core/Data/Redis/RedisAnalyzer.Memory.cs
+++ b/Opserver.Core/Data/Redis/RedisAnalyzer.Memory.cs
@@ -56,6 +56,7 @@ namespace StackExchange.Opserver.Data.Redis
                 ClientName = "Status-MemoryAnalyzer",
                 Password = connectionInfo.Password,
                 Ssl = connectionInfo.Settings.UseSSL,
+                SslProtocols = connectionInfo.SslProtocols,
                 EndPoints =
                 {
                     { connectionInfo.Host, connectionInfo.Port }

--- a/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
+++ b/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
@@ -42,7 +42,7 @@ namespace StackExchange.Opserver.Data.Redis
             for (int i = 0; i < protocols.Length; i++)
             {
                 SslProtocols protocol;
-                if (Enum.TryParse(protocols[i].Trim(), ignoreCase: true, out protocol))
+                if (Enum.TryParse(protocols[i].Trim(), true, out protocol))
                 {
                     result |= protocol;
                 }

--- a/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
+++ b/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
@@ -42,7 +42,7 @@ namespace StackExchange.Opserver.Data.Redis
             for (int i = 0; i < protocols.Length; i++)
             {
                 SslProtocols protocol;
-                if (Enum.TryParse(protocols[i].Trim(), out protocol))
+                if (Enum.TryParse(protocols[i].Trim(), ignoreCase: true, out protocol))
                 {
                     result |= protocol;
                 }

--- a/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
+++ b/Opserver.Core/Data/Redis/RedisConnectionInfo.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
+using System.Security.Authentication;
 using StackExchange.Opserver.Helpers;
 using StackExchange.Redis;
 
@@ -11,6 +13,7 @@ namespace StackExchange.Opserver.Data.Redis
         public string Host => Server.HostName;
         public int Port => Settings.Port;
         public string Password => Settings.Password;
+        public SslProtocols? SslProtocols => ParseSslProtocols(Settings.SslProtocols);
         public RedisFeatures Features { get; internal set; }
         public RedisHost Server { get; }
         internal RedisSettings.Instance Settings { get; set; }
@@ -24,5 +27,28 @@ namespace StackExchange.Opserver.Data.Redis
         public List<IPAddress> IPAddresses => AppCache.GetHostAddresses(Host);
 
         public override string ToString() => $"{Name} ({Host}:{Port})";
+
+        private static SslProtocols? ParseSslProtocols(string sslProtocols)
+        {
+            if (String.IsNullOrWhiteSpace(sslProtocols))
+            {
+                return null;
+            }
+
+            var result = System.Security.Authentication.SslProtocols.None;
+
+            var protocols = sslProtocols.Split(',');
+
+            for (int i = 0; i < protocols.Length; i++)
+            {
+                SslProtocols protocol;
+                if (Enum.TryParse(protocols[i].Trim(), out protocol))
+                {
+                    result |= protocol;
+                }
+            }
+
+            return result;
+        }
     }
 }

--- a/Opserver.Core/Data/Redis/RedisInstance.cs
+++ b/Opserver.Core/Data/Redis/RedisInstance.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using StackExchange.Opserver.Helpers;
 using StackExchange.Opserver.Data.Dashboard;
 using StackExchange.Redis;
+using System.Security.Authentication;
 
 namespace StackExchange.Opserver.Data.Redis
 {
@@ -29,6 +30,7 @@ namespace StackExchange.Opserver.Data.Redis
         public string Password => ConnectionInfo.Password;
         public int Port => ConnectionInfo.Port;
         public bool UseSsl => ConnectionInfo.Settings.UseSSL;
+        public SslProtocols? SslProtocols => ConnectionInfo.SslProtocols;
 
         private string _hostAndPort;
         public string HostAndPort => _hostAndPort ?? (_hostAndPort = Host + ":" + Port.ToString());
@@ -130,7 +132,8 @@ namespace StackExchange.Opserver.Data.Redis
                 ConnectTimeout = 60000,
                 AllowAdmin = allowAdmin,
                 Password = Password,
-                Ssl=UseSsl,
+                Ssl = UseSsl,
+                SslProtocols = SslProtocols,
                 EndPoints =
                 {
                     { ConnectionInfo.Host, ConnectionInfo.Port }

--- a/Opserver.Core/Settings/RedisSettings.cs
+++ b/Opserver.Core/Settings/RedisSettings.cs
@@ -84,6 +84,12 @@ namespace StackExchange.Opserver
             public bool UseSSL { get; set; } = false;
 
             /// <summary>
+            /// Specify the ssl protocols that should be used.
+            /// You can specifiy multiple protocols separated by a comma.
+            /// </summary>
+            public string SslProtocols{ get; set; }
+
+            /// <summary>
             /// Regular expressions collection to crawl keys against, to break out Redis DB usage
             /// </summary>
             public Dictionary<string, string> AnalysisRegexes { get; set; } = new Dictionary<string, string>();

--- a/Opserver/Config/RedisSettings.example.json
+++ b/Opserver/Config/RedisSettings.example.json
@@ -71,9 +71,10 @@
           "name": "Machine Learning",
           "port": 6379,
           "password": "superSecret", // Instance has a password
-          "useSSL": "true" // Connect via SSL (not built into redis itself - default is false)
-        }
-      ]
-    }
-  ]
-}
+          "useSSL": "true", // Connect via SSL (not built into redis itself - default is false)
+          "sslProtocols": "Tls11,Tls12" // Warning: case sensitive. Valid values are Ssl2, Ssl3, Tls, Tls11, Tls12
+        }                     
+      ]                       
+    }                        
+  ]                          
+}                            

--- a/Opserver/Config/RedisSettings.example.json
+++ b/Opserver/Config/RedisSettings.example.json
@@ -72,7 +72,7 @@
           "port": 6379,
           "password": "superSecret", // Instance has a password
           "useSSL": "true", // Connect via SSL (not built into redis itself - default is false)
-          "sslProtocols": "Tls11,Tls12" // Warning: case sensitive. Valid values are Ssl2, Ssl3, Tls, Tls11, Tls12
+          "sslProtocols": "Tls11,Tls12" // Case insensitve. Valid values are Ssl2, Ssl3, Tls, Tls11, Tls12
         }                     
       ]                       
     }                        


### PR DESCRIPTION
Microsoft decided to "Remove TLS 1.0 and 1.1 from use with Azure Cache for Redis" so, if you are using Opserver to monitor Azure Redis instances you need TLS 1.2.

More info here: https://docs.microsoft.com/en-us/azure/azure-cache-for-redis/cache-remove-tls-10-11