### PR TITLE
Adding Adaptive join to query plan

### DIFF
--- a/Opserver.Core/Data/SQL/QueryPlans/ShowPlanXML.generated.cs
+++ b/Opserver.Core/Data/SQL/QueryPlans/ShowPlanXML.generated.cs
@@ -3861,6 +3861,10 @@ namespace StackExchange.Opserver.Data.SQL.QueryPlans
     {
 
         /// <remarks/>
+        [System.Xml.Serialization.XmlEnumAttribute("Adaptive Join")]
+        AdaptiveJoin,
+
+        /// <remarks/>
         Assert,
 
         /// <remarks/>


### PR DESCRIPTION
Adaptive joins are now a thing (https://docs.microsoft.com/en-us/sql/relational-databases/performance/intelligent-query-processing?view=sql-server-ver15) but an exception is thrown if you try to view a query plan that contains one. It's not listed under PhysicalOpTypes. 