### PR TITLE
Revert "Updated some Nugets:"

### DIFF
--- a/Opserver.Core/Opserver.Core.csproj
+++ b/Opserver.Core/Opserver.Core.csproj
@@ -8,13 +8,13 @@
     <DebugType>pdbonly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.60.16" />
+    <PackageReference Include="Dapper" Version="1.50.5" />
     <PackageReference Include="Enums.NET" Version="2.3.2" />
     <PackageReference Include="Jil" Version="2.16.0" />
-    <PackageReference Include="MiniProfiler.Shared" Version="4.0.180" />
+    <PackageReference Include="MiniProfiler.Shared" Version="4.0.138" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.0.85" />
-    <PackageReference Include="StackExchange.Redis" Version="2.0.602" />
+    <PackageReference Include="StackExchange.Exceptional.Shared" Version="2.0.0-rc2.29" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.513" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework) == 'net461'">
     <Reference Include="System.DirectoryServices" />

--- a/Opserver/Opserver.csproj
+++ b/Opserver/Opserver.csproj
@@ -45,8 +45,8 @@
     <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.6" />
     <PackageReference Include="Microsoft.AspNet.Web.Optimization" Version="1.1.3" />
     <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="1.0.7.0" />
-    <PackageReference Include="MiniProfiler.Mvc5" Version="4.0.180" />
-    <PackageReference Include="StackExchange.Exceptional" Version="2.0.85" />
+    <PackageReference Include="MiniProfiler.Mvc5" Version="4.0.138" />
+    <PackageReference Include="StackExchange.Exceptional" Version="2.0.0-rc2.29" />
     <PackageReference Include="WebGrease" Version="1.6.0" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />


### PR DESCRIPTION
Reverts opserver/Opserver#348

This just causes too many issues in the old world - reverting until the .NET Core 3.1 branch which simplifies everything.