### PR TITLE
[Minor] Allow to set Modules.Sql.refreshIntervalSeconds from config

### DIFF
--- a/Opserver.Core/Settings/SQLSettings.cs
+++ b/Opserver.Core/Settings/SQLSettings.cs
@@ -15,7 +15,7 @@ namespace StackExchange.Opserver
         /// How many seconds before polling a node or cluster for status again
         /// If specified at the node or cluster level, that setting overrides
         /// </summary>
-        public int RefreshIntervalSeconds { get; } = 60;
+        public int RefreshIntervalSeconds { get; set; } = 60;
 
         /// <summary>
         /// The default connection string to use when connecting to servers, $ServerName$ will be parameterized


### PR DESCRIPTION
It seems that `Modules.Sql.refreshIntervalSeconds` value was silently ignored, while users may expect this to set value for underlying instances

![image](https://user-images.githubusercontent.com/959800/81068971-1df71180-8ed9-11ea-8c8c-f3645fc5d80e.png)
