### PR TITLE
Fix for #380 - BosunDataProvider: ApiResponse can be null

### DIFF
--- a/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.cs
+++ b/src/Opserver.Core/Data/Dashboard/Providers/BosunDataProvider.cs
@@ -175,7 +175,7 @@ namespace Opserver.Data.Dashboard.Providers
                 iface.NodeId,
                 TagCombos.AllDirectionsForInterface(iface.Id));
 
-            return JoinNetwork(apiResponse.Series) ?? new List<DoubleGraphPoint>();
+            return JoinNetwork(apiResponse?.Series) ?? new List<DoubleGraphPoint>();
         }
 
         private List<DoubleGraphPoint> JoinNetwork(List<PointSeries> allSeries)


### PR DESCRIPTION
Small fix to correct ApiResponse can be null #380 . It was correctly handled in the 3 other locations