### PR TITLE
Elastic: support an Authorization header

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -252,6 +252,9 @@ In elastic, it's not a good idea to trust any specific node to be up. It's sugge
         "ny-search02",
         "ny-search03"
       ]
+      // The exact value of the authorization header, if any, to send on cluster requests
+      // Here's an example for hosted Elastic:
+      // "authorizationHeader": "ApiKey <your key>"
     },
     {
       "name": "NY Development",

--- a/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
+++ b/src/Opserver.Core/Data/Elastic/ElasticCluster.cs
@@ -20,7 +20,7 @@ namespace Opserver.Data.Elastic
         public ElasticCluster(ElasticModule module, ElasticSettings.Cluster cluster) : base(module, cluster.Name)
         {
             Settings = cluster;
-            KnownNodes = cluster.Nodes.Select(n => new ElasticNode(n)).ToList();
+            KnownNodes = cluster.Nodes.Select(n => new ElasticNode(n, Settings)).ToList();
         }
 
         public override string NodeType => "elastic";

--- a/src/Opserver.Core/Settings/ElasticSettings.cs
+++ b/src/Opserver.Core/Settings/ElasticSettings.cs
@@ -30,6 +30,11 @@ namespace Opserver
             public string Description { get; set; }
 
             /// <summary>
+            /// The authorization header, if any, to send on requests.
+            /// </summary>
+            public string AuthorizationHeader { get; set; }
+
+            /// <summary>
             /// How many seconds before polling this cluster for status again
             /// </summary>
             public int RefreshIntervalSeconds { get; set; } = 120;

--- a/src/Opserver.Web/Security/EveryonesAnAdminProvider.cs
+++ b/src/Opserver.Web/Security/EveryonesAnAdminProvider.cs
@@ -13,6 +13,7 @@ namespace Opserver.Security
         public override SecurityProviderFlowType FlowType => SecurityProviderFlowType.Username;
         public EveryonesAnAdminProvider(SecuritySettings settings) : base(settings) { }
 
+        internal override bool InAdminGroups(User user, StatusModule module) => true;
         protected override bool InGroupsCore(User user, string[] groupNames) => true;
 
         protected override bool TryValidateToken(UserNamePasswordToken token, out ClaimsPrincipal claimsPrincipal)


### PR DESCRIPTION
This allows for monitoring hosted Elastic indexes and such.

Note: this also fixes the "Everyone's an Admin" provider to always work. The previous code subtly required _some_ groups to be specified in config for it to actually work.