### PR TITLE
Add url, host, start date and end date UI filters for Exceptions

### DIFF
--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -91,7 +91,7 @@ namespace Opserver.Data.Exceptions
                 async () =>
                 {
                     var result = await QueryListAsync<Application>($"Applications Fetch: {Name}", @"
-Select ApplicationName as Name, 
+Select ApplicationName as Name,
        Sum(DuplicateCount) as ExceptionCount,
 	   Sum(Case When CreationDate > DateAdd(Second, -@RecentSeconds, GETUTCDATE()) Then DuplicateCount Else 0 End) as RecentExceptionCount,
 	   MAX(CreationDate) as MostRecent
@@ -175,7 +175,7 @@ Select ApplicationName as Name,
             public string Url { get; set; }
             public string Host { get; set; }
 
-            public bool IsNonDefault =>
+            public bool HasFilterOptions =>
               Host.HasValue() || Url.HasValue() || StartDate.HasValue || EndDate.HasValue;
 
             public string NormalizedStartDate => NormalizeDateTime(StartDate);
@@ -382,10 +382,10 @@ Select e.Id,
         public Task<int> DeleteErrorsAsync(List<Guid> ids)
         {
             return ExecTaskAsync($"{nameof(DeleteErrorsAsync)}({ids.Count} Guids) for {Name}", @"
-Update Exceptions 
-   Set DeletionDate = GETUTCDATE() 
- Where DeletionDate Is Null 
-   And IsProtected = 0 
+Update Exceptions
+   Set DeletionDate = GETUTCDATE()
+ Where DeletionDate Is Null
+   And IsProtected = 0
    And GUID In @ids", new { ids });
         }
 
@@ -398,8 +398,8 @@ Update Exceptions
                 using (var c = await GetConnectionAsync())
                 {
                     sqlError = await c.QueryFirstOrDefaultAsync<Error>(@"
-    Select Top 1 * 
-      From Exceptions 
+    Select Top 1 *
+      From Exceptions
      Where GUID = @guid", new { guid }, commandTimeout: QueryTimeout);
                 }
                 if (sqlError == null) return null;
@@ -423,7 +423,7 @@ Update Exceptions
         public async Task<bool> ProtectErrorAsync(Guid guid)
         {
               return await ExecTaskAsync($"{nameof(ProtectErrorAsync)}() (guid: {guid}) for {Name}", @"
-Update Exceptions 
+Update Exceptions
    Set IsProtected = 1, DeletionDate = Null
  Where GUID = @guid", new {guid}) > 0;
         }
@@ -431,9 +431,9 @@ Update Exceptions
         public async Task<bool> DeleteErrorAsync(Guid guid)
         {
             return await ExecTaskAsync($"{nameof(DeleteErrorAsync)}() (guid: {guid}) for {Name}", @"
-Update Exceptions 
-   Set DeletionDate = GETUTCDATE() 
- Where GUID = @guid 
+Update Exceptions
+   Set DeletionDate = GETUTCDATE()
+ Where GUID = @guid
    And DeletionDate Is Null", new { guid }) > 0;
         }
 

--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -187,21 +187,9 @@ Select ApplicationName as Name,
                 }
             }
 
-            public string NormalizedStartDate
-            {
-                get
-                {
-                    return NormalizeDateTime(StartDate);
-                }
-            }
+            public string NormalizedStartDate => NormalizeDateTime(StartDate);
 
-            public string NormalizedEndDate
-            {
-                get
-                {
-                    return NormalizeDateTime(EndDate);
-                }
-            }
+            public string NormalizedEndDate => NormalizeDateTime(EndDate);
 
             public override int GetHashCode()
             {

--- a/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
+++ b/src/Opserver.Core/Data/Exceptions/ExceptionStore.cs
@@ -175,17 +175,8 @@ Select ApplicationName as Name,
             public string Url { get; set; }
             public string Host { get; set; }
 
-            public bool IsNonDefault
-            {
-                get
-                {
-                    if (Host.HasValue()) return true;
-                    if (Url.HasValue()) return true;
-                    if (StartDate != null) return true;
-                    if (EndDate != null) return true;
-                    return false;
-                }
-            }
+            public bool IsNonDefault =>
+              Host.HasValue() || Url.HasValue() || StartDate.HasValue || EndDate.HasValue;
 
             public string NormalizedStartDate => NormalizeDateTime(StartDate);
 

--- a/src/Opserver.Web/ContentSource/js/Scripts.js
+++ b/src/Opserver.Web/ContentSource/js/Scripts.js
@@ -784,7 +784,7 @@ Status.SQL = (function () {
                 }
             }
         }
-        
+
         Status.loaders.register({
             '#/cluster/': loadCluster,
             '#/plan/': loadPlan,
@@ -1053,8 +1053,28 @@ Status.Exceptions = (function () {
             store: options.store,
             group: options.group,
             log: options.log,
-            sort: options.sort
+            sort: options.sort,
+            url: options.url,
+            host: options.host,
+            startDate: options.startDate,
+            endDate: options.endDate
         };
+
+        var filterOptions = {
+            modalClass: 'modal-md',
+            buttons: {
+                "Apply Filters": function (e) {
+                    $(this).find('#exceptionFiltersForm').submit();
+                    return false;
+                }
+            }
+        }
+
+        Status.loaders.register({
+            '#/exceptions/filters': function () {
+                Status.popup('exceptions/filters' + window.location.search, null, filterOptions);
+            }
+        });
 
         // TODO: Set refresh params
         function getLoadCount() {
@@ -1437,6 +1457,10 @@ Status.Exceptions = (function () {
         });
 
     }
+
+    $(document).ready(function () {
+        $('[data-toggle="tooltip"]').tooltip();
+    });
 
     return {
         init: init

--- a/src/Opserver.Web/ContentSource/js/Scripts.js
+++ b/src/Opserver.Web/ContentSource/js/Scripts.js
@@ -1064,7 +1064,7 @@ Status.Exceptions = (function () {
             modalClass: 'modal-md',
             buttons: {
                 "Apply Filters": function (e) {
-                    $(this).find('#exceptionFiltersForm').submit();
+                    $(this).find('form').submit();
                     return false;
                 }
             }

--- a/src/Opserver.Web/Controllers/ExceptionsController.cs
+++ b/src/Opserver.Web/Controllers/ExceptionsController.cs
@@ -91,7 +91,7 @@ namespace Opserver.Controllers
                 Url = CurrentUrl,
                 Host = CurrentHost,
                 StartDate = CurrentStartDate,
-                EndDate = CurrentEndDate
+                EndDate = CurrentEndDate,
             };
 
             if (GetParam("q").HasValue())
@@ -319,7 +319,8 @@ namespace Opserver.Controllers
         }
 
         [Route("exceptions/filters")]
-        public async Task<ActionResult> Filters() {
+        public async Task<ActionResult> Filters()
+        {
             var model = GetModel(null);
             model.SearchParams = await GetSearchAsync();
             return PartialView("Exceptions.Filters", model);

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
@@ -4,7 +4,7 @@
     Exceptions Filters
 </h4>
 
-<form id="exceptionFiltersForm" class="form-horizontal" action="@Url.Action(nameof(ExceptionsController.Exceptions))" method="GET">
+<form class="form-horizontal" action="@Url.Action(nameof(ExceptionsController.Exceptions))" method="GET">
     <input type="hidden" name="store" value="@Model.Store?.Name"/>
     <input type="hidden" name="group" value="@Model.Group?.Name"/>
     <input type="hidden" name="log" value="@Model.Log?.Name"/>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Filters.cshtml
@@ -1,0 +1,49 @@
+﻿@model ExceptionsModel
+
+<h4 class="modal-title">
+    Exceptions Filters
+</h4>
+
+<form id="exceptionFiltersForm" class="form-horizontal" action="@Url.Action(nameof(ExceptionsController.Exceptions))" method="GET">
+    <input type="hidden" name="store" value="@Model.Store?.Name"/>
+    <input type="hidden" name="group" value="@Model.Group?.Name"/>
+    <input type="hidden" name="log" value="@Model.Log?.Name"/>
+    <input type="hidden" name="sort" value="@Model.Sort"/>
+    @{
+        string tooltipMessage = "This filter supports wildcards by using '*'. They may slow down queries, leading wildcards are usually slower than trailing ones.";
+    }
+    <div class="form-group form-group-sm">
+        <label class="col-md-3 control-label" for="url">
+            <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="@tooltipMessage"></i>
+            Url
+        </label>
+        <div class="col-md-9">
+            <input class="form-control" type="text" value="@Model.SearchParams.Url" name="url" placeholder="url"/>
+        </div>
+    </div>
+    <div class="form-group form-group-sm">
+        <label class="col-md-3 control-label" for="host">
+            <i class="fa fa-question-circle" aria-hidden="true" data-toggle="tooltip" title="@tooltipMessage"></i>
+            Host
+        </label>
+        <div class="col-md-9">
+            <input class="form-control" type="text" value="@Model.SearchParams.Host" name="host" placeholder="host"/>
+        </div>
+    </div>
+    <div class="form-group form-group-sm">
+        <label class="col-md-3 control-label" for="startDate">
+            Start Date
+        </label>
+        <div class="col-md-9">
+            <input type="datetime-local" name="startDate" value="@Model.SearchParams.NormalizedStartDate">
+        </div>
+    </div>
+        <div class="form-group form-group-sm">
+        <label class="col-md-3 control-label" for="endDate">
+            End Date
+        </label>
+        <div class="col-md-9">
+            <input type="datetime-local" name="endDate" value="@Model.SearchParams.NormalizedEndDate">
+        </div>
+    </div>
+</form>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Navigation.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Navigation.cshtml
@@ -1,7 +1,7 @@
 ﻿@model ExceptionsModel
 @if (Model.Groups.Count > 1)
 {
-    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
+    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, url = Model.SearchParams.Url, host = Model.SearchParams.Host, startDate = Model.SearchParams.NormalizedStartDate, endDate = Model.SearchParams.NormalizedEndDate })" title="View All" class="btn btn-xs@(Model.ShowAll ? " btn-primary" : null)">View All</a>
 }
 @foreach (var g in Model.Groups)
 {
@@ -13,7 +13,7 @@
     var btnClass = active ? "btn-primary" : "";
     var app = Model.Log != null && g.Applications.Contains(Model.Log) ? Model.Log : null;
     <div class="btn-group dropdown">
-        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name })" class="btn btn-xs @btnClass">
+        <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, url = Model.SearchParams.Url, host = Model.SearchParams.Host, startDate = Model.SearchParams.NormalizedStartDate, endDate = Model.SearchParams.NormalizedEndDate })" class="btn btn-xs @btnClass">
             @g.Name
             @if (app != null)
             {
@@ -32,7 +32,7 @@
             @foreach (var a in g.Applications)
                 {
                 <li class="@(Model.Log?.Name == a.Name || g.Applications.Count == 1 ? " active" : null)">
-                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name })">
+                    <a href="@Url.Action(nameof(ExceptionsController.Exceptions), new { store = Model.Store.Name, group = g.Name, log = a.Name, url = Model.SearchParams.Url, host = Model.SearchParams.Host, startDate = Model.SearchParams.NormalizedStartDate, endDate = Model.SearchParams.NormalizedEndDate })">
                         @a.Name
                         <span class="badge js-exception-total" data-name="@g.Name-@a.Name">@a.ExceptionCount.ToComma()</span>
                     </a>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Table.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Table.cshtml
@@ -23,6 +23,7 @@
     <h5 class="page-header">
         <span class="js-exception-title">@Model.Title</span>
         <span class="pull-right">
+            <a href="#/exceptions/filters" class="hover-pulsate@(Model.SearchParams.IsNonDefault ? " text-warning" : "")"><i class="fa fa-filter" aria-hidden="true"></i></a>
             @if (Model.ShowClearLink)
             {
                 <a class="text-danger hover-pulsate js-clear-all" href="#" data-url="@Url.Action(nameof(ExceptionsController.Delete), Context.Request.Query.ToRouteValues())">@Icon.X Clear all non-protected errors</a>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.Table.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.Table.cshtml
@@ -23,7 +23,7 @@
     <h5 class="page-header">
         <span class="js-exception-title">@Model.Title</span>
         <span class="pull-right">
-            <a href="#/exceptions/filters" class="hover-pulsate@(Model.SearchParams.IsNonDefault ? " text-warning" : "")"><i class="fa fa-filter" aria-hidden="true"></i></a>
+            <a href="#/exceptions/filters" class="hover-pulsate@(Model.SearchParams.HasFilterOptions ? " text-warning" : "")"><i class="fa fa-filter" aria-hidden="true"></i></a>
             @if (Model.ShowClearLink)
             {
                 <a class="text-danger hover-pulsate js-clear-all" href="#" data-url="@Url.Action(nameof(ExceptionsController.Delete), Context.Request.Query.ToRouteValues())">@Icon.X Clear all non-protected errors</a>

--- a/src/Opserver.Web/Views/Exceptions/Exceptions.cshtml
+++ b/src/Opserver.Web/Views/Exceptions/Exceptions.cshtml
@@ -3,6 +3,10 @@
     var store = Model.Store?.Name;
     var group = Model.Group?.Name;
     var log = Model.Log?.Name;
+    var url = Model.SearchParams.Url;
+    var host = Model.SearchParams.Host;
+    var normalizedStartDate = Model.SearchParams.NormalizedStartDate;
+    var normalizedEndDate = Model.SearchParams.NormalizedEndDate;
     var exceptions = Model.Errors;
 
     this.SetPageTitle(Model.Title);
@@ -24,7 +28,11 @@
                 loadMore: @(Model.LoadAsyncSize),
                 enablePreviews: @Module.Settings.EnablePreviews.ToJson(),
                 showDeleted: @Model.ShowDeleted.ToJson(),
-                search: @Model.Search.ToJson()
+                search: @Model.Search.ToJson(),
+                url: @url.ToJson(),
+                host: @host.ToJson(),
+                startDate: @normalizedStartDate.ToJson(),
+                endDate: @normalizedEndDate.ToJson()
             });
         });
     </script>
@@ -32,21 +40,21 @@
 <div class="js-refresh" data-name="exceptions-header">
     @if (Module.Stores.Count > 1)
     {
-    <ul class="nav nav-tabs nav-tabs-right">
-        @foreach (var s in Module.Stores)
-        {
-            <li class="@(Model.Store == s ? "active" : null)">
-                <a href="?store=@s.Name" title="@s.Description">@s.Name <span class="badge"><span class="js-exception-total js-exception-store" data-name="@s.Name">@s.TotalExceptionCount.ToComma()</span></span></a>
-            </li>
-        }
-    </ul>
+        <ul class="nav nav-tabs nav-tabs-right">
+            @foreach (var s in Module.Stores)
+            {
+                <li class="@(Model.Store == s ? "active" : null)">
+                    <a href="?store=@s.Name" title="@s.Description">@s.Name <span class="badge"><span class="js-exception-total js-exception-store" data-name="@s.Name">@s.TotalExceptionCount.ToComma()</span></span></a>
+                </li>
+            }
+        </ul>
     }
     <partial name="PollInfo" model="@(new Opserver.Views.PollInfoModel { Nodes = Module.Stores, Name = "exceptions" })" />
     @if (anyLoaded)
     {
-    <div class="js-exception-counts">
-        <partial name="Exceptions.Navigation" model="Model" />
-    </div>
+        <div class="js-exception-counts">
+            <partial name="Exceptions.Navigation" model="Model" />
+        </div>
     }
 </div>
 @if (anyLoaded)


### PR DESCRIPTION
### Summary
(I couldn't reopen the previous PR so I've created a new one with my changes on top of the new main branch) Closes #404

Added a filter UI on Exceptions page to filter by Url, Host, Start Date and End Date. I've followed the same UI pattern as the one used on the SQL active/top page filters. These have been features requested at Stack that will be very handy to search for specific exceptions without manipulating the opserver url or search box.
* Filter by Url: filters exceptions by Url, wildcards such as * or % can be entered.
* Filter by Host: filters exceptions by Host, wildcards such as * or % can be entered.
* Filter by Start Date: filters exceptions that were created from Start Date onwards.
* Filter by End Date: filters exceptions that were created from End Date backwards.

![image](https://user-images.githubusercontent.com/24233455/157451210-c0c34c87-5286-4eca-b205-d51abea5c08e.png)
![image](https://user-images.githubusercontent.com/24233455/157451246-270a7145-a619-414f-af49-04637d13b9af.png)
![image](https://user-images.githubusercontent.com/24233455/157452349-c4a0e5a5-8587-4a19-94ff-66c890386965.png)

The picker date format and text is regionalized based on browser/pc settings. The value the picker sends to the controller has always the fixed format of YYYY-MM-DDThh:mm. It also has an option to clear the field.

### What I have tested
I've run OpServer locally with a local DB containing test Exceptions data. Tested the following behaviour:
* Filter by Url, with and without wildcards
* Filter by Host, with and without wildcards
* Filter by Start Date
* Filter by End Date
* Any combination of the above filters, Url + Host, Start Date + End Date, etc.
* Load More feature loads more exceptions using the current filters
* Changing the Group or Log mantains the current filter values
* Changing the Store resets the filter value