### PR TITLE
Update GitVersioning and SourceLink.GitHub deps

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,7 @@
     <ProjectCapability Include="DynamicFileNesting" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When I build the OpServer project in CircleCI I see the following exception:
```
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018: The "Nerdbank.GitVersioning.Tasks.GetBuildVersion" task failed unexpectedly.
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018: System.TypeInitializationException: The type initializer for 'LibGit2Sharp.Core.NativeMethods' threw an exception.
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:  ---> System.DllNotFoundException: Unable to load shared library '/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/MSBuildCore/../runtimes/ubuntu.18.04-x64/native/libgit2-106a5f2.so' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: libssl.so.1.1: cannot open shared object file: No such file or directory
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at System.Runtime.InteropServices.NativeLibrary.LoadFromPath(String libraryName, Boolean throwOnError)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at System.Runtime.InteropServices.NativeLibrary.Load(String libraryPath)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at System.Runtime.Loader.AssemblyLoadContext.LoadUnmanagedDllFromPath(String unmanagedDllPath)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at Nerdbank.GitVersioning.GitLoaderContext.LoadUnmanagedDll(String unmanagedDllName)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at System.Runtime.Loader.AssemblyLoadContext.ResolveUnmanagedDll(String unmanagedDllName, IntPtr gchManagedAssemblyLoadContext)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.Core.NativeMethods.git_libgit2_init()
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.Core.NativeMethods.InitializeNativeLibrary()
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.Core.NativeMethods..cctor()
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    --- End of inner exception stack trace ---
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.Core.NativeMethods.git_libgit2_opts(Int32 option, UInt32 level, String path)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.Core.Proxy.git_libgit2_opts_set_search_path(ConfigurationLevel level, String path)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at LibGit2Sharp.GlobalSettings.SetConfigSearchPaths(ConfigurationLevel level, String[] paths)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at Nerdbank.GitVersioning.GitExtensions.OpenGitRepo(String pathUnderGitRepo, Boolean useDefaultConfigSearchPaths)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at Nerdbank.GitVersioning.VersionOracle.Create(String projectDirectory, String gitRepoDirectory, ICloudBuild cloudBuild, Nullable`1 overrideBuildNumberOffset, String projectPathRelativeToGitRepoRoot)
/home/circleci/.nuget/packages/nerdbank.gitversioning/3.3.37/build/Nerdbank.GitVersioning.Inner.targets(17,5): error MSB4018:    at Nerdbank.GitVersioning.Tasks.GetBuildVersion.ExecuteInner()

Build FAILED.
```

I think this issue was solved in a later version of Nerdbank GitVersioning, so I'm upgrading it in hopes that I'll fix the build issue.